### PR TITLE
Add .vscode to .gitignore

### DIFF
--- a/app/.gitignore
+++ b/app/.gitignore
@@ -18,6 +18,7 @@
 # misc
 .DS_Store
 *.pem
+.vscode
 
 # debug
 npm-debug.log*

--- a/app/.vscode/settings.json
+++ b/app/.vscode/settings.json
@@ -1,4 +1,0 @@
-{
-    "typescript.tsdk": "node_modules\\typescript\\lib",
-    "typescript.enablePromptUseWorkspaceTsdk": true
-}


### PR DESCRIPTION
This is a temporary fix to prevent the .vscode folder from being committed.

This folder is generated by Visual Studio Code and contains settings specific to the editor.