### PR TITLE
feat: add ellipsis to blog card title

### DIFF
--- a/app/app/DefaultTags.tsx
+++ b/app/app/DefaultTags.tsx
@@ -3,11 +3,11 @@ import Script from 'next/script';
 const DefaultTags = () => {
     return (
         <>
-            <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
-            <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
-            <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
-            <link rel="manifest" href="/site.webmanifest" />
-            <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5" />
+            <link rel="apple-touch-icon" sizes="180x180" href="/favicons/apple-touch-icon.png" />
+            <link rel="icon" type="image/png" sizes="32x32" href="/favicons/favicon-32x32.png" />
+            <link rel="icon" type="image/png" sizes="16x16" href="/favicons/favicon-16x16.png" />
+            <link rel="manifest" href="/favicons/site.webmanifest" />
+            <link rel="mask-icon" href="/favicons/safari-pinned-tab.svg" color="#5bbad5" />
             <meta name="msapplication-TileColor" content="#da532c" />
             <meta name="theme-color" content="#ffffff" />
             <Script

--- a/app/app/blog/card.tsx
+++ b/app/app/blog/card.tsx
@@ -1,13 +1,22 @@
-import {type PostData} from 'lib/posts';
+import { type PostData } from 'lib/posts';
 import Link from 'next/link';
 import styles from 'styles/app/blog/card.module.css';
-import {utcToZonedTime, format as formatTZ} from 'date-fns-tz';
+import { utcToZonedTime, format as formatTZ } from 'date-fns-tz';
 
-const Card = ({post}: {post: PostData}) => {
+const truncateTitle = (title: string) => {
+    const maxLength = 52;
+    if (title.length > maxLength) {
+        return title.slice(0, maxLength) + '...';
+    } else {
+        return title;
+    }
+};
+
+const Card = ({ post }: { post: PostData }) => {
     return (
         <article className={styles.card}>
             <Link href={`/blog/${post.slug}`} key={post.slug}>
-                <h2>{post.title}</h2>
+                <h2>{truncateTitle(post.title)}</h2>
                 <footer>
                     {formatTZ(
                         utcToZonedTime(post.createdAt * 1000, 'Asia/Tokyo'),

--- a/app/styles/app/blog/card.module.css
+++ b/app/styles/app/blog/card.module.css
@@ -24,9 +24,6 @@
     font-size: 1.5rem;
     font-weight: bold;
     margin: 0.5rem 0;
-    overflow: hidden;
-    white-space: nowrap;
-    text-overflow: ellipsis;
 }
 
 .card footer {


### PR DESCRIPTION
The title of the blog card was too long and was breaking the layout.

This commit adds ellipsis to the title to prevent this.
