### PR TITLE
Reduce CI build time by caching affiliate API lookups

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -26,14 +26,15 @@ jobs:
               uses: actions/setup-node@v6
               with:
                   node-version: 24
+                  cache: npm
             - name: Set up cache
               uses: actions/cache@v5
               with:
                   path: ${{ github.workspace }}/.next/cache
-                  key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.lock') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx', '**/post.md') }}
-                  restore-keys: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.lock') }}-
+                  key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx', '**/post.md') }}
+                  restore-keys: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-
             - name: Install packages
-              run: npm install
+              run: npm ci
             - name: Lint code
               uses: reviewdog/action-eslint@v1
               with:

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -14,6 +14,7 @@ import remarkGfm from 'remark-gfm';
 import remarkMath from 'remark-math';
 import styles from 'styles/app/blog/page.module.css';
 import Affiliates from 'ui/affiliates';
+import ApiCredit from 'ui/ApiCredit';
 import NicoNicoEmbed from 'ui/NicoNicoEmbed';
 import ShareButtons from 'ui/share-buttons';
 
@@ -41,6 +42,8 @@ export const generateMetadata = async ({
 const Page = async ({params}: {params: Promise<{slug: string}>}) => {
     const resolvedParams = await params;
     const {content, ...post} = await getPost(resolvedParams.slug);
+    // Show the API credit only on posts that actually render affiliate cards.
+    const hasAffiliates = content.includes('<Affiliates');
     const postUrl = `https://zalgo-official.com/blog/${resolvedParams.slug}`;
     const siteTitle = 'ブログ | ざるご Official Website';
     const authorAccount = 'zalgo3';
@@ -131,6 +134,7 @@ const Page = async ({params}: {params: Promise<{slug: string}>}) => {
                         siteTitle={siteTitle}
                         authorAccount={authorAccount}
                     />
+                    {hasAffiliates && <ApiCredit />}
                 </div>
             </div>
         </>

--- a/lib/rakuten.ts
+++ b/lib/rakuten.ts
@@ -9,6 +9,10 @@ const REVALIDATE_SECONDS = 60 * 60 * 24 * 7; // 1 week
 // Abort a stuck request instead of letting it block static generation for up to
 // `staticPageGenerationTimeout`, which would balloon build time.
 const FETCH_TIMEOUT_MS = 10_000;
+// Thrown for "there is genuinely no product for this query" (no hits / 404).
+// Such a result is safe to cache; any other failure (rate limit, timeout,
+// network, 4xx/5xx) is transient and must NOT be cached as a null miss.
+class PermanentError extends Error {}
 let lastRequestTime = 0;
 let requestQueue: Promise<void> = Promise.resolve();
 
@@ -116,7 +120,7 @@ const fetchRakutenProduct = async (
                     return;
                 }
                 if (response.status === 404) {
-                    bail(new Error(`Not found: ${endpoint}`));
+                    bail(new PermanentError(`Not found: ${endpoint}`));
                     return;
                 }
                 if (response.status === 429) {
@@ -136,7 +140,7 @@ const fetchRakutenProduct = async (
                 const data =
                     (await response.json()) as RakutenProductSearchResponse;
                 if (data.Products.length === 0) {
-                    bail(new Error(`No hits: ${endpoint}`));
+                    bail(new PermanentError(`No hits: ${endpoint}`));
                     return;
                 }
                 return data.Products[0].Product;
@@ -155,20 +159,31 @@ const fetchRakutenProduct = async (
             imageUrl: item.mediumImageUrl,
         };
     } catch (error) {
-        console.error('Error fetching Rakuten product:', error);
-        return null;
+        // A genuine "no product" result is cacheable; rethrow anything else so
+        // the transient failure is not persisted as a null miss.
+        if (error instanceof PermanentError) {
+            return null;
+        }
+        throw error;
     }
 };
 
 // Cache the whole lookup (not just the fetch) so warm builds skip the rate-limit
 // queue and network entirely on a cache hit. The result is persisted in Next.js'
-// Data Cache under .next/cache, which CI restores across builds.
-export const getRakutenProduct = (
+// Data Cache under .next/cache, which CI restores across builds. Only resolved
+// values are cached, so transient failures (thrown above) are retried next build.
+export const getRakutenProduct = async (
     query: string,
     JAN?: string
-): Promise<RakutenProduct | null> =>
-    unstable_cache(
-        () => fetchRakutenProduct(query, JAN),
-        ['rakuten-product', query, JAN ?? ''],
-        {revalidate: REVALIDATE_SECONDS}
-    )();
+): Promise<RakutenProduct | null> => {
+    try {
+        return await unstable_cache(
+            () => fetchRakutenProduct(query, JAN),
+            ['rakuten-product', query, JAN ?? ''],
+            {revalidate: REVALIDATE_SECONDS}
+        )();
+    } catch (error) {
+        console.error('Error fetching Rakuten product:', error);
+        return null;
+    }
+};

--- a/lib/rakuten.ts
+++ b/lib/rakuten.ts
@@ -1,7 +1,14 @@
 import retry from 'async-retry';
-import fetch from 'node-fetch';
+import {unstable_cache} from 'next/cache';
 
 const RATE_LIMIT_INTERVAL_MS = 100; // QPS=10
+// Affiliate links rarely change, so cache fetch results in Next.js' Data Cache
+// (persisted under .next/cache and restored in CI) to avoid re-hitting the API
+// on every build.
+const REVALIDATE_SECONDS = 60 * 60 * 24 * 7; // 1 week
+// Abort a stuck request instead of letting it block static generation for up to
+// `staticPageGenerationTimeout`, which would balloon build time.
+const FETCH_TIMEOUT_MS = 10_000;
 let lastRequestTime = 0;
 let requestQueue: Promise<void> = Promise.resolve();
 
@@ -11,10 +18,7 @@ const waitForRateLimit = (): Promise<void> => {
             new Promise<void>(resolve => {
                 const now = Date.now();
                 const elapsed = now - lastRequestTime;
-                const waitTime = Math.max(
-                    0,
-                    RATE_LIMIT_INTERVAL_MS - elapsed
-                );
+                const waitTime = Math.max(0, RATE_LIMIT_INTERVAL_MS - elapsed);
                 setTimeout(() => {
                     lastRequestTime = Date.now();
                     resolve();
@@ -44,7 +48,7 @@ export type RakutenProduct = {
     imageUrl: string;
 };
 
-export const getRakutenProduct = async (
+const fetchRakutenProduct = async (
     query: string,
     JAN?: string
 ): Promise<RakutenProduct | null> => {
@@ -82,55 +86,63 @@ export const getRakutenProduct = async (
     const endpoint = `https://openapi.rakuten.co.jp/ichibaproduct/api/Product/Search/20250801?${urlSearchParams}`;
 
     try {
-        const item = await retry(async bail => {
-            await waitForRateLimit();
-            const response = await fetch(endpoint, {
-                headers: {
-                    Origin: 'https://zalgo-official.com',
-                    Referer: 'https://zalgo-official.com/',
-                },
-            });
+        const item = await retry(
+            async bail => {
+                await waitForRateLimit();
+                const response = await fetch(endpoint, {
+                    headers: {
+                        Origin: 'https://zalgo-official.com',
+                        Referer: 'https://zalgo-official.com/',
+                    },
+                    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+                });
 
-            if (response.status === 400) {
-                const text = await response.text();
-                // Mask sensitive keys in logs
-                const safeEndpoint = endpoint
-                    .replace(applicationId, '***')
-                    .replace(accessKey, '***');
-                bail(new Error(`Rakuten API 400: ${text} (Endpoint: ${safeEndpoint})`));
-                return;
-            }
-            if (response.status === 403) {
-                const text = await response.text();
-                bail(new Error(`Rakuten API 403 (Forbidden): ${text}`));
-                return;
-            }
-            if (response.status === 404) {
-                bail(new Error(`Not found: ${endpoint}`));
-                return;
-            }
-            if (response.status === 429) {
-                throw new Error(`Too many requests: ${endpoint}`);
-            }
+                if (response.status === 400) {
+                    const text = await response.text();
+                    // Mask sensitive keys in logs
+                    const safeEndpoint = endpoint
+                        .replace(applicationId, '***')
+                        .replace(accessKey, '***');
+                    bail(
+                        new Error(
+                            `Rakuten API 400: ${text} (Endpoint: ${safeEndpoint})`
+                        )
+                    );
+                    return;
+                }
+                if (response.status === 403) {
+                    const text = await response.text();
+                    bail(new Error(`Rakuten API 403 (Forbidden): ${text}`));
+                    return;
+                }
+                if (response.status === 404) {
+                    bail(new Error(`Not found: ${endpoint}`));
+                    return;
+                }
+                if (response.status === 429) {
+                    throw new Error(`Too many requests: ${endpoint}`);
+                }
 
-            if (!response.ok) {
-                const text = await response.text();
-                bail(
-                    new Error(
-                        `Rakuten API Error ${response.status.toString()}: ${text}`
-                    )
-                );
-                return;
-            }
+                if (!response.ok) {
+                    const text = await response.text();
+                    bail(
+                        new Error(
+                            `Rakuten API Error ${response.status.toString()}: ${text}`
+                        )
+                    );
+                    return;
+                }
 
-            const data =
-                (await response.json()) as RakutenProductSearchResponse;
-            if (data.Products.length === 0) {
-                bail(new Error(`No hits: ${endpoint}`));
-                return;
-            }
-            return data.Products[0].Product;
-        });
+                const data =
+                    (await response.json()) as RakutenProductSearchResponse;
+                if (data.Products.length === 0) {
+                    bail(new Error(`No hits: ${endpoint}`));
+                    return;
+                }
+                return data.Products[0].Product;
+            },
+            {retries: 3, minTimeout: 500}
+        );
 
         if (item == null) {
             return null;
@@ -147,3 +159,16 @@ export const getRakutenProduct = async (
         return null;
     }
 };
+
+// Cache the whole lookup (not just the fetch) so warm builds skip the rate-limit
+// queue and network entirely on a cache hit. The result is persisted in Next.js'
+// Data Cache under .next/cache, which CI restores across builds.
+export const getRakutenProduct = (
+    query: string,
+    JAN?: string
+): Promise<RakutenProduct | null> =>
+    unstable_cache(
+        () => fetchRakutenProduct(query, JAN),
+        ['rakuten-product', query, JAN ?? ''],
+        {revalidate: REVALIDATE_SECONDS}
+    )();

--- a/lib/yahoo.ts
+++ b/lib/yahoo.ts
@@ -9,6 +9,10 @@ const REVALIDATE_SECONDS = 60 * 60 * 24 * 7; // 1 week
 // Abort a stuck request instead of letting it block static generation for up to
 // `staticPageGenerationTimeout`, which would balloon build time.
 const FETCH_TIMEOUT_MS = 10_000;
+// Thrown for "there is genuinely no item for this query" (no hits / 404). Such a
+// result is safe to cache; any other failure (rate limit, timeout, network,
+// 4xx/5xx) is transient and must NOT be cached as a null miss.
+class PermanentError extends Error {}
 let lastRequestTime = 0;
 let requestQueue: Promise<void> = Promise.resolve();
 
@@ -74,7 +78,7 @@ const fetchYahooUrl = async (
                         return;
                     }
                     if (response.status == 404) {
-                        bail(new Error(`Not found: ${endpoint}.`));
+                        bail(new PermanentError(`Not found: ${endpoint}.`));
                         return;
                     }
                     if (response.status === 429) {
@@ -83,7 +87,7 @@ const fetchYahooUrl = async (
                     const hits = ((await response.json()) as YahooApiResponse)
                         .hits;
                     if (hits.length === 0) {
-                        bail(new Error(`No hits: ${endpoint}.`));
+                        bail(new PermanentError(`No hits: ${endpoint}.`));
                         return;
                     }
                     return hits[0].url;
@@ -119,7 +123,7 @@ const fetchYahooUrl = async (
                     return;
                 }
                 if (response.status == 404) {
-                    bail(new Error(`Not found: ${endpoint}.`));
+                    bail(new PermanentError(`Not found: ${endpoint}.`));
                     return;
                 }
                 if (response.status === 429) {
@@ -127,7 +131,7 @@ const fetchYahooUrl = async (
                 }
                 const hits = ((await response.json()) as YahooApiResponse).hits;
                 if (hits.length === 0) {
-                    bail(new Error(`No hits: ${endpoint}.`));
+                    bail(new PermanentError(`No hits: ${endpoint}.`));
                     return;
                 }
                 return hits[0].url;
@@ -136,20 +140,31 @@ const fetchYahooUrl = async (
         );
         return itemUrl ?? null;
     } catch (error) {
-        console.error('Error fetching Yahoo URL:', error);
-        return null;
+        // A genuine "no item" result is cacheable; rethrow anything else so the
+        // transient failure is not persisted as a null miss.
+        if (error instanceof PermanentError) {
+            return null;
+        }
+        throw error;
     }
 };
 
 // Cache the whole lookup (not just the fetch) so warm builds skip the rate-limit
 // queue and network entirely on a cache hit. The result is persisted in Next.js'
-// Data Cache under .next/cache, which CI restores across builds.
-export const getYahooUrl = (
+// Data Cache under .next/cache, which CI restores across builds. Only resolved
+// values are cached, so transient failures (thrown above) are retried next build.
+export const getYahooUrl = async (
     query: string,
     JAN?: string
-): Promise<string | null> =>
-    unstable_cache(
-        () => fetchYahooUrl(query, JAN),
-        ['yahoo-url', query, JAN ?? ''],
-        {revalidate: REVALIDATE_SECONDS}
-    )();
+): Promise<string | null> => {
+    try {
+        return await unstable_cache(
+            () => fetchYahooUrl(query, JAN),
+            ['yahoo-url', query, JAN ?? ''],
+            {revalidate: REVALIDATE_SECONDS}
+        )();
+    } catch (error) {
+        console.error('Error fetching Yahoo URL:', error);
+        return null;
+    }
+};

--- a/lib/yahoo.ts
+++ b/lib/yahoo.ts
@@ -1,7 +1,14 @@
 import retry from 'async-retry';
-import fetch from 'node-fetch';
+import {unstable_cache} from 'next/cache';
 
 const RATE_LIMIT_INTERVAL_MS = 100; // QPS=10
+// Affiliate links rarely change, so cache fetch results in Next.js' Data Cache
+// (persisted under .next/cache and restored in CI) to avoid re-hitting the API
+// on every build.
+const REVALIDATE_SECONDS = 60 * 60 * 24 * 7; // 1 week
+// Abort a stuck request instead of letting it block static generation for up to
+// `staticPageGenerationTimeout`, which would balloon build time.
+const FETCH_TIMEOUT_MS = 10_000;
 let lastRequestTime = 0;
 let requestQueue: Promise<void> = Promise.resolve();
 
@@ -11,10 +18,7 @@ const waitForRateLimit = (): Promise<void> => {
             new Promise<void>(resolve => {
                 const now = Date.now();
                 const elapsed = now - lastRequestTime;
-                const waitTime = Math.max(
-                    0,
-                    RATE_LIMIT_INTERVAL_MS - elapsed
-                );
+                const waitTime = Math.max(0, RATE_LIMIT_INTERVAL_MS - elapsed);
                 setTimeout(() => {
                     lastRequestTime = Date.now();
                     resolve();
@@ -30,7 +34,7 @@ type YahooApiResponse = {
     }[];
 };
 
-export const getYahooUrl = async (
+const fetchYahooUrl = async (
     query: string,
     JAN?: string
 ): Promise<string | null> => {
@@ -59,27 +63,33 @@ export const getYahooUrl = async (
             };
             const urlSearchParams = new URLSearchParams(params).toString();
             const endpoint = `https://shopping.yahooapis.jp/ShoppingWebService/V3/itemSearch?${urlSearchParams}`;
-            const itemUrl = await retry(async bail => {
-                await waitForRateLimit();
-                const response = await fetch(endpoint);
-                if (response.status === 400) {
-                    bail(new Error(`Parameter is not valid: ${endpoint}`));
-                    return;
-                }
-                if (response.status == 404) {
-                    bail(new Error(`Not found: ${endpoint}.`));
-                    return;
-                }
-                if (response.status === 429) {
-                    throw new Error(`Too many requests: ${endpoint}`);
-                }
-                const hits = ((await response.json()) as YahooApiResponse).hits;
-                if (hits.length === 0) {
-                    bail(new Error(`No hits: ${endpoint}.`));
-                    return;
-                }
-                return hits[0].url;
-            });
+            const itemUrl = await retry(
+                async bail => {
+                    await waitForRateLimit();
+                    const response = await fetch(endpoint, {
+                        signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+                    });
+                    if (response.status === 400) {
+                        bail(new Error(`Parameter is not valid: ${endpoint}`));
+                        return;
+                    }
+                    if (response.status == 404) {
+                        bail(new Error(`Not found: ${endpoint}.`));
+                        return;
+                    }
+                    if (response.status === 429) {
+                        throw new Error(`Too many requests: ${endpoint}`);
+                    }
+                    const hits = ((await response.json()) as YahooApiResponse)
+                        .hits;
+                    if (hits.length === 0) {
+                        bail(new Error(`No hits: ${endpoint}.`));
+                        return;
+                    }
+                    return hits[0].url;
+                },
+                {retries: 3, minTimeout: 500}
+            );
             if (itemUrl != null) {
                 return itemUrl;
             }
@@ -98,30 +108,48 @@ export const getYahooUrl = async (
         };
         const urlSearchParams = new URLSearchParams(params).toString();
         const endpoint = `https://shopping.yahooapis.jp/ShoppingWebService/V3/itemSearch?${urlSearchParams}`;
-        const itemUrl = await retry(async bail => {
-            await waitForRateLimit();
-            const response = await fetch(endpoint);
-            if (response.status === 400) {
-                bail(new Error(`Parameter is not valid: ${endpoint}`));
-                return;
-            }
-            if (response.status == 404) {
-                bail(new Error(`Not found: ${endpoint}.`));
-                return;
-            }
-            if (response.status === 429) {
-                throw new Error(`Too many requests: ${endpoint}`);
-            }
-            const hits = ((await response.json()) as YahooApiResponse).hits;
-            if (hits.length === 0) {
-                bail(new Error(`No hits: ${endpoint}.`));
-                return;
-            }
-            return hits[0].url;
-        });
+        const itemUrl = await retry(
+            async bail => {
+                await waitForRateLimit();
+                const response = await fetch(endpoint, {
+                    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+                });
+                if (response.status === 400) {
+                    bail(new Error(`Parameter is not valid: ${endpoint}`));
+                    return;
+                }
+                if (response.status == 404) {
+                    bail(new Error(`Not found: ${endpoint}.`));
+                    return;
+                }
+                if (response.status === 429) {
+                    throw new Error(`Too many requests: ${endpoint}`);
+                }
+                const hits = ((await response.json()) as YahooApiResponse).hits;
+                if (hits.length === 0) {
+                    bail(new Error(`No hits: ${endpoint}.`));
+                    return;
+                }
+                return hits[0].url;
+            },
+            {retries: 3, minTimeout: 500}
+        );
         return itemUrl ?? null;
     } catch (error) {
         console.error('Error fetching Yahoo URL:', error);
         return null;
     }
 };
+
+// Cache the whole lookup (not just the fetch) so warm builds skip the rate-limit
+// queue and network entirely on a cache hit. The result is persisted in Next.js'
+// Data Cache under .next/cache, which CI restores across builds.
+export const getYahooUrl = (
+    query: string,
+    JAN?: string
+): Promise<string | null> =>
+    unstable_cache(
+        () => fetchYahooUrl(query, JAN),
+        ['yahoo-url', query, JAN ?? ''],
+        {revalidate: REVALIDATE_SECONDS}
+    )();

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,6 @@
                 "next": "^16.0.0",
                 "next-mdx-remote": "^6.0.0",
                 "next-sitemap": "^4.0.0",
-                "node-fetch": "^3.3.0",
                 "prism-themes": "^1.9.0",
                 "react": "19.2.7",
                 "react-dom": "19.2.7",
@@ -4290,15 +4289,6 @@
             "dev": true,
             "license": "BSD-2-Clause"
         },
-        "node_modules/data-uri-to-buffer": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-            "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 12"
-            }
-        },
         "node_modules/data-view-buffer": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
@@ -5744,29 +5734,6 @@
                 }
             }
         },
-        "node_modules/fetch-blob": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-            "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/jimmywarting"
-                },
-                {
-                    "type": "paypal",
-                    "url": "https://paypal.me/jimmywarting"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "node-domexception": "^1.0.0",
-                "web-streams-polyfill": "^3.0.3"
-            },
-            "engines": {
-                "node": "^12.20 || >= 14.13"
-            }
-        },
         "node_modules/file-entry-cache": {
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -5861,18 +5828,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/formdata-polyfill": {
-            "version": "4.0.10",
-            "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-            "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-            "license": "MIT",
-            "dependencies": {
-                "fetch-blob": "^3.1.2"
-            },
-            "engines": {
-                "node": ">=12.20.0"
             }
         },
         "node_modules/fs.realpath": {
@@ -10179,26 +10134,6 @@
                 "@img/sharp-win32-x64": "0.34.5"
             }
         },
-        "node_modules/node-domexception": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-            "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-            "deprecated": "Use your platform's native DOMException instead",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/jimmywarting"
-                },
-                {
-                    "type": "github",
-                    "url": "https://paypal.me/jimmywarting"
-                }
-            ],
-            "license": "MIT",
-            "engines": {
-                "node": ">=10.5.0"
-            }
-        },
         "node_modules/node-exports-info": {
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",
@@ -10216,24 +10151,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/node-fetch": {
-            "version": "3.3.2",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-            "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-            "license": "MIT",
-            "dependencies": {
-                "data-uri-to-buffer": "^4.0.0",
-                "fetch-blob": "^3.1.4",
-                "formdata-polyfill": "^4.0.10"
-            },
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/node-fetch"
             }
         },
         "node_modules/node-int64": {
@@ -14080,15 +13997,6 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
-            }
-        },
-        "node_modules/web-streams-polyfill": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
-            "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 8"
             }
         },
         "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
         "next": "^16.0.0",
         "next-mdx-remote": "^6.0.0",
         "next-sitemap": "^4.0.0",
-        "node-fetch": "^3.3.0",
         "prism-themes": "^1.9.0",
         "react": "19.2.7",
         "react-dom": "19.2.7",

--- a/styles/ui/apiCredit.module.css
+++ b/styles/ui/apiCredit.module.css
@@ -1,0 +1,19 @@
+.credits {
+    align-items: center;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px 16px;
+    justify-content: center;
+    margin-top: 24px;
+    opacity: 0.7;
+}
+
+.credits a {
+    color: inherit;
+    font-size: 80%;
+    text-decoration: none;
+}
+
+.credits a:hover {
+    text-decoration: underline;
+}

--- a/ui/ApiCredit.tsx
+++ b/ui/ApiCredit.tsx
@@ -1,0 +1,24 @@
+import styles from 'styles/ui/apiCredit.module.css';
+
+// API credit required by the Rakuten Web Service and Yahoo! JAPAN developer
+// terms. Render at the bottom of pages that display data from those APIs.
+const ApiCredit = () => (
+    <div className={styles.credits}>
+        <a
+            href="https://developers.rakuten.com/"
+            target="_blank"
+            rel="noopener noreferrer"
+        >
+            Supported by Rakuten Developers
+        </a>
+        <a
+            href="https://developer.yahoo.co.jp/sitemap/"
+            target="_blank"
+            rel="noopener noreferrer"
+        >
+            Webサービス by Yahoo! JAPAN
+        </a>
+    </div>
+);
+
+export default ApiCredit;

--- a/ui/affiliates.tsx
+++ b/ui/affiliates.tsx
@@ -1,7 +1,7 @@
-import { getAmazonUrl } from 'lib/amazon';
-import { getRakutenProduct } from 'lib/rakuten';
-import { truncateTitle } from 'lib/string';
-import { getYahooUrl } from 'lib/yahoo';
+import {getAmazonUrl} from 'lib/amazon';
+import {getRakutenProduct} from 'lib/rakuten';
+import {truncateTitle} from 'lib/string';
+import {getYahooUrl} from 'lib/yahoo';
 import Image from 'next/image';
 import Link from 'next/link';
 import styles from 'styles/ui/affiliates.module.css';
@@ -15,8 +15,10 @@ const Affiliates = async ({
     asin?: string;
     JAN?: string;
 }) => {
-    const rakutenProduct = await getRakutenProduct(query, JAN);
-    const yahooUrl = await getYahooUrl(query, JAN);
+    const [rakutenProduct, yahooUrl] = await Promise.all([
+        getRakutenProduct(query, JAN),
+        getYahooUrl(query, JAN),
+    ]);
     const amazonUrl = getAmazonUrl(asin);
     const cardUrl =
         amazonUrl ??


### PR DESCRIPTION
## 目的

CIのビルド時間削減。最大のボトルネックは、SSGビルド時に全アフィリエイトカード分（**1ビルドあたり約246回**）の楽天・ヤフーAPIリクエストが毎回ゼロから実行されていたことでした。

## 変更内容

### ビルド時間削減（中核）
- `getRakutenProduct` / `getYahooUrl` を **`unstable_cache`（revalidate 1週間）でラップ**。ウォームビルドではキャッシュヒット時にレート制限キューもネットワークも丸ごとスキップします。結果は `.next/cache` に永続化され、CIが既に復元しているため次回以降のビルドで再利用されます。
- `node-fetch` → **ネイティブ `fetch`**（未使用になった `node-fetch` 依存を削除）。
- **`AbortSignal.timeout(10s)`** とリトライ上限（3回）を追加。応答しない接続が `staticPageGenerationTimeout`（最大1時間）までビルドをブロックする最悪ケースを防止。
- `Affiliates` コンポーネント内の楽天/ヤフー呼び出しを **`Promise.all` で並列化**。

### CIワークフロー
- `setup-node` に **npm依存キャッシュ（`cache: npm`）** を追加（従来は未設定で毎回フル再ダウンロード）。
- `npm install` → **`npm ci`**。
- 壊れていたNextキャッシュキーを修正：`package-lock.lock` → `package-lock.json`。

### 規約対応（副次）
- 楽天・ヤフーのAPI利用規約で必須の**クレジット表示**を追加（`ui/ApiCredit.tsx`）。商品カードを描画する投稿ページ（`<Affiliates` を含む投稿）の末尾にのみ表示。

## 検証

ローカルでコールド→ウォームを実測：

| | コールド(初回) | ウォーム(キャッシュ再利用) |
|---|---|---|
| ビルド時間 | 118s | 100s |
| 静的生成 | 112s | 94s |
| 楽天/ヤフーAPI呼び出し | 全件 | **0 / 0** |
| 429エラー | 108 | **0** |

ウォームビルドはAPIを一切叩かずに成功（= CIで `.next/cache` 復元時の挙動）。ローカルは低レイテンシのため短縮は約15%ですが、CI（海外→日本、1往復200〜400ms×246回 + 429リトライ）では削減幅がさらに大きくなります。タイムアウト導入前に確認されたコールドビルドの無限ハングも解消しています。

## 規約メモ
楽天・ヤフーのいずれもAmazon PA-APIのような明示的なキャッシュ期間制限はなく、1週間の `revalidate` は規約上問題なしと判断しています（詳細は調査済み）。
