### PR TITLE
Add minimumReleaseAge to Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,7 @@
     "extends": ["config:base"],
     "timezone": "Asia/Tokyo",
     "automerge": true,
-    "branchConcurrentLimit": 0
+    "branchConcurrentLimit": 0,
+    "minimumReleaseAge": "3 days",
+    "internalChecksFilter": "strict"
 }


### PR DESCRIPTION
## 目的

依存パッケージの自動更新（Renovate, `automerge: true`）に **`minimumReleaseAge`** を追加し、公開直後のバージョンが自動マージされないようにします。サプライチェーン攻撃（悪意ある公開直後バージョン）や、公開直後に取り下げ／修正される壊れたリリースへの対策です。

## 変更

```diff
   "automerge": true,
   "branchConcurrentLimit": 0,
+  "minimumReleaseAge": "3 days",
+  "internalChecksFilter": "strict"
```

- **`minimumReleaseAge: "3 days"`** — リリースが公開されてから3日経過するまで更新ブランチ/PRの作成・自動マージを保留。
- **`internalChecksFilter: "strict"`** — 現行Renovate（v36+）ではデフォルトが `strict` ですが、automerge併用時に「期間到達までマージを確実に保留」させる意図を明示するため併記（公式の推奨パターン）。

## 補足
- 待機日数 `3 days` はサプライチェーン対策で広く使われる既定値です。より慎重にするなら `"7 days"` 等へ変更可能（この1行を編集するだけ）。
- 形式・オプション名はRenovate公式ドキュメントで確認済み。
