### PR TITLE
Fix build-perf, SEO and a11y issues found in site diagnosis

### DIFF
--- a/__tests__/lib/posts.test.ts
+++ b/__tests__/lib/posts.test.ts
@@ -1,3 +1,5 @@
+import {describe, expect, it} from '@jest/globals';
+
 import type {PostData} from '../../lib/posts';
 
 describe('PostData type', () => {
@@ -5,19 +7,13 @@ describe('PostData type', () => {
         const postData: PostData = {
             slug: 'test-slug',
             title: 'Test Title',
-            createdAt: '2022-01-01T00:00:00.000Z',
-            updatedAt: '2022-01-01T00:00:00.000Z',
+            createdAt: 1640995200,
+            updatedAt: 1640995200,
         };
 
         expect(postData).toHaveProperty('slug', 'test-slug');
         expect(postData).toHaveProperty('title', 'Test Title');
-        expect(postData).toHaveProperty(
-            'createdAt',
-            '2022-01-01T00:00:00.000Z'
-        );
-        expect(postData).toHaveProperty(
-            'updatedAt',
-            '2022-01-01T00:00:00.000Z'
-        );
+        expect(postData).toHaveProperty('createdAt', 1640995200);
+        expect(postData).toHaveProperty('updatedAt', 1640995200);
     });
 });

--- a/app/Breadcrumbs.tsx
+++ b/app/Breadcrumbs.tsx
@@ -1,3 +1,4 @@
+import {siteUrl} from 'lib/siteMetadata';
 import Link from 'next/link';
 import styles from 'styles/app/Breadcrumbs.module.css';
 
@@ -11,8 +12,25 @@ type BreadcrumbsProps = {
 };
 
 const Breadcrumbs = ({items}: BreadcrumbsProps) => {
+    const jsonLd = {
+        '@context': 'https://schema.org',
+        '@type': 'BreadcrumbList',
+        itemListElement: [
+            {'@type': 'ListItem', position: 1, name: 'ホーム', item: siteUrl},
+            ...items.map((item, index) => ({
+                '@type': 'ListItem',
+                position: index + 2,
+                name: item.label,
+                item: `${siteUrl}${item.href}`,
+            })),
+        ],
+    };
     return (
         <nav aria-label="breadcrumb" className={styles.container}>
+            <script
+                type="application/ld+json"
+                dangerouslySetInnerHTML={{__html: JSON.stringify(jsonLd)}}
+            />
             <ol className={styles.list}>
                 <li className={styles.listItem}>
                     <Link href="/">ホーム</Link>

--- a/app/blog/DisplayPosts.tsx
+++ b/app/blog/DisplayPosts.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import {type PostData} from 'lib/posts';
 import styles from 'styles/app/blog/DisplayPosts.module.css';
 

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -4,6 +4,8 @@ import {YouTubeEmbed} from '@next/third-parties/google';
 import {format as formatTZ, toZonedTime} from 'date-fns-tz';
 import {getPost, getPostAll} from 'lib/posts';
 import remarkImagesToFullPaths from 'lib/remarkImagesToFullPaths';
+import {defaultOgImage, siteUrl} from 'lib/siteMetadata';
+import {excerpt} from 'lib/string';
 import type {Metadata} from 'next';
 import {MDXRemote} from 'next-mdx-remote/rsc';
 import rehypeKatex from 'rehype-katex';
@@ -26,15 +28,23 @@ export const generateMetadata = async ({
     params: Promise<{slug: string}>;
 }): Promise<Metadata> => {
     const resolvedParams = await params;
-    const post = await getPost(resolvedParams.slug);
+    const {content, data} = await getPost(resolvedParams.slug);
+    const description = excerpt(content);
+    const url = `${siteUrl}/blog/${resolvedParams.slug}`;
     return {
-        title: post.data.title,
+        title: data.title,
+        description,
         openGraph: {
-            title: post.data.title,
-            url: `https://zalgo-official.com/blog/${resolvedParams.slug}`,
+            title: data.title,
+            description,
+            url,
+            type: 'article',
+            images: [defaultOgImage],
         },
         twitter: {
-            title: post.data.title,
+            title: data.title,
+            description,
+            images: [defaultOgImage],
         },
     };
 };
@@ -51,8 +61,24 @@ const Page = async ({params}: {params: Promise<{slug: string}>}) => {
         {label: 'ブログ', href: '/blog'},
         {label: post.data.title, href: `/blog/${resolvedParams.slug}`},
     ];
+    const articleJsonLd = {
+        '@context': 'https://schema.org',
+        '@type': 'Article',
+        headline: post.data.title,
+        datePublished: new Date(post.data.createdAt * 1000).toISOString(),
+        dateModified: new Date(post.data.updatedAt * 1000).toISOString(),
+        author: {'@type': 'Person', name: 'Hiroki Tanabe'},
+        mainEntityOfPage: postUrl,
+        url: postUrl,
+    };
     return (
         <>
+            <script
+                type="application/ld+json"
+                dangerouslySetInnerHTML={{
+                    __html: JSON.stringify(articleJsonLd),
+                }}
+            />
             <Breadcrumbs items={breadcrumbs} />
             <div className={`${styles.container} container`}>
                 <div>

--- a/app/blog/layout.tsx
+++ b/app/blog/layout.tsx
@@ -1,3 +1,4 @@
+import {defaultOgImage, siteUrl} from 'lib/siteMetadata';
 import type {Metadata} from 'next';
 
 import Header from '../header';
@@ -15,13 +16,15 @@ export const metadata: Metadata = {
         title: 'ブログ',
         description:
             '歌い手/ゲーム実況者/データサイエンティストであるざるごのブログ',
-        url: 'https://zalgo-official.com/blog',
+        url: `${siteUrl}/blog`,
         siteName: 'ざるご Official Website',
+        images: [defaultOgImage],
     },
     twitter: {
         title: 'ブログ',
         description:
             '歌い手/ゲーム実況者/データサイエンティストであるざるごのブログ',
+        images: [defaultOgImage],
     },
 };
 

--- a/app/blog/search.tsx
+++ b/app/blog/search.tsx
@@ -15,6 +15,7 @@ const Search = () => {
                 className={styles.input}
                 name="q"
                 placeholder="サイト内検索"
+                aria-label="サイト内検索"
             />
             <button type="submit" className={styles.button} name="sa">
                 検索

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import 'styles/global.css';
 
 import {GoogleAnalytics} from '@next/third-parties/google';
+import {defaultOgImage, siteUrl} from 'lib/siteMetadata';
 import type {Metadata} from 'next';
 import Script from 'next/script';
 
@@ -8,6 +9,7 @@ import Footer from './footer';
 import GoogleAds from './google-ads';
 
 export const metadata: Metadata = {
+    metadataBase: new URL(siteUrl),
     title: {
         default: 'ざるご Official Website',
         template: '%s | ざるご Official Website',
@@ -18,10 +20,11 @@ export const metadata: Metadata = {
         title: 'ざるご Official Website',
         description:
             '歌い手/ゲーム実況者/データサイエンティストであるざるごのオフィシャルウェブサイト',
-        url: 'https://zalgo-official.com',
+        url: siteUrl,
         siteName: 'ざるご Official Website',
         locale: 'ja_JP',
         type: 'website',
+        images: [defaultOgImage],
     },
     icons: {
         icon: [
@@ -36,6 +39,7 @@ export const metadata: Metadata = {
         description:
             '歌い手/ゲーム実況者/データサイエンティストであるざるごのオフィシャルウェブサイト',
         creator: '@zalgo_video',
+        images: [defaultOgImage],
     },
 };
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -100,7 +100,11 @@ const Page = () => {
                         <h2>オリジナルグッズ販売中</h2>
                         <div className={styles.suzuriProducts}>
                             <div className={styles.suzuriProduct}>
-                                <a href="https://suzuri.jp/zalgo/15079349/acrylic-keychain/50x50mm/clear">
+                                <a
+                                    href="https://suzuri.jp/zalgo/15079349/acrylic-keychain/50x50mm/clear"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                >
                                     <Image
                                         src="/images/acrylic-keychain.png"
                                         alt="アクリルキーホルダー"
@@ -110,13 +114,19 @@ const Page = () => {
                                 </a>
                                 <a
                                     href="https://suzuri.jp/zalgo/15079349/acrylic-keychain/50x50mm/clear"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
                                     className={styles.link}
                                 >
                                     アクリルキーホルダー
                                 </a>
                             </div>
                             <div className={styles.suzuriProduct}>
-                                <a href="https://suzuri.jp/zalgo/15079384/can-badge/75mm/white">
+                                <a
+                                    href="https://suzuri.jp/zalgo/15079384/can-badge/75mm/white"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                >
                                     <Image
                                         src="/images/can-badge.png"
                                         alt="缶バッジ"
@@ -126,6 +136,8 @@ const Page = () => {
                                 </a>
                                 <a
                                     href="https://suzuri.jp/zalgo/15079384/can-badge/75mm/white"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
                                     className={styles.link}
                                 >
                                     缶バッジ

--- a/lib/discography.ts
+++ b/lib/discography.ts
@@ -71,9 +71,7 @@ const addAmazonTag = (urlString: string | undefined): string | undefined => {
     return `${urlString}${separator}tag=${tag}`;
 };
 
-export const getDiscographyAll = async (
-    options: Options = {}
-): Promise<DiscographyItem[]> => {
+const loadDiscography = async (): Promise<DiscographyItem[]> => {
     const items = (
         await Promise.all(
             (await fs.readdir(discographyPath)).map(async slug => {
@@ -134,10 +132,25 @@ export const getDiscographyAll = async (
                 return p1.data.slug.localeCompare(p2.data.slug);
             }
             return p2.data.createdAt - p1.data.createdAt;
-        })
-        .slice(0, options.limit);
+        });
 
     return items;
+};
+
+// Memoize during production builds for the same reason as the posts list: each
+// statically generated page called this (via getDiscographyItem), re-reading
+// every item and spawning two `git log` processes per item. Skipped in dev.
+let cachedDiscography: Promise<DiscographyItem[]> | undefined;
+const loadDiscographyCached = (): Promise<DiscographyItem[]> =>
+    process.env.NODE_ENV === 'production'
+        ? (cachedDiscography ??= loadDiscography())
+        : loadDiscography();
+
+export const getDiscographyAll = async (
+    options: Options = {}
+): Promise<DiscographyItem[]> => {
+    const items = await loadDiscographyCached();
+    return options.limit ? items.slice(0, options.limit) : items;
 };
 
 export const getDiscographyDataAll = async (

--- a/lib/posts.ts
+++ b/lib/posts.ts
@@ -11,7 +11,7 @@ type Options = {
     limit?: number;
 };
 
-export const getPostAll = async (options: Options = {}): Promise<Post[]> => {
+const loadPosts = async (): Promise<Post[]> => {
     const posts = (
         await Promise.all(
             (await fs.readdir(postsPath)).map(async slug => {
@@ -55,10 +55,25 @@ export const getPostAll = async (options: Options = {}): Promise<Post[]> => {
                 return p1.data.slug.localeCompare(p2.data.slug);
             }
             return p2.data.createdAt - p1.data.createdAt;
-        })
-        .slice(0, options.limit);
+        });
 
     return posts;
+};
+
+// Memoize the full post list during production builds. Every statically
+// generated page used to call getPostAll (directly or via getPost), and each
+// call re-read every post and spawned two `git log` processes per post — an
+// O(N^2) blow-up in subprocess spawns. The list is immutable during a build, so
+// caching it is safe. Skipped in development so post edits stay fresh.
+let cachedPosts: Promise<Post[]> | undefined;
+const loadPostsCached = (): Promise<Post[]> =>
+    process.env.NODE_ENV === 'production'
+        ? (cachedPosts ??= loadPosts())
+        : loadPosts();
+
+export const getPostAll = async (options: Options = {}): Promise<Post[]> => {
+    const posts = await loadPostsCached();
+    return options.limit ? posts.slice(0, options.limit) : posts;
 };
 
 export const getPostDataAll = async (

--- a/lib/siteMetadata.ts
+++ b/lib/siteMetadata.ts
@@ -1,0 +1,5 @@
+export const siteUrl = 'https://zalgo-official.com';
+
+// No dedicated 1200x630 OG asset exists yet; fall back to the site icon so link
+// previews at least show branding. Replace with a proper OG image when available.
+export const defaultOgImage = '/favicons/android-chrome-256x256.png';

--- a/lib/string.ts
+++ b/lib/string.ts
@@ -6,3 +6,20 @@ export const truncateTitle = (title: string) => {
         return title;
     }
 };
+
+// Build a plain-text meta description from MDX post content. Heuristically
+// strips code, MDX/HTML tags, links, images and markdown syntax so each post
+// gets a unique description instead of inheriting the generic site one.
+export const excerpt = (markdown: string, maxLength = 120): string => {
+    const text = markdown
+        .replace(/```[\s\S]*?```/g, ' ') // fenced code blocks
+        .replace(/`[^`]*`/g, ' ') // inline code
+        .replace(/<[^>]*>/g, ' ') // MDX/HTML tags
+        .replace(/!\[[^\]]*\]\([^)]*\)/g, ' ') // images
+        .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1') // links -> text
+        .replace(/\$+[^$]*\$+/g, ' ') // math
+        .replace(/[#>*_~`|-]/g, ' ') // markdown symbols
+        .replace(/\s+/g, ' ')
+        .trim();
+    return text.length > maxLength ? text.slice(0, maxLength) + '…' : text;
+};

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,5 +1,22 @@
+const securityHeaders = [
+    {key: 'X-Content-Type-Options', value: 'nosniff'},
+    {key: 'X-Frame-Options', value: 'SAMEORIGIN'},
+    {key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin'},
+    {
+        key: 'Strict-Transport-Security',
+        value: 'max-age=63072000; includeSubDomains; preload',
+    },
+    {
+        key: 'Permissions-Policy',
+        value: 'camera=(), microphone=(), geolocation=()',
+    },
+];
+
 export default {
-    staticPageGenerationTimeout: 3600,
+    // 5 minutes is a generous per-page ceiling now that affiliate lookups are
+    // cached and the post list is no longer re-read per page; the previous
+    // 3600s masked those slow builds.
+    staticPageGenerationTimeout: 300,
     reactStrictMode: true,
     images: {
         remotePatterns: [
@@ -11,4 +28,10 @@ export default {
             },
         ],
     },
+    headers: async () => [
+        {
+            source: '/:path*',
+            headers: securityHeaders,
+        },
+    ],
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,38 +1,36 @@
 {
-  "compilerOptions": {
-    "target": "es5",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
+    "compilerOptions": {
+        "target": "es2017",
+        "lib": ["dom", "dom.iterable", "esnext"],
+        "allowJs": true,
+        "skipLibCheck": true,
+        "strict": true,
+        "forceConsistentCasingInFileNames": true,
+        "noEmit": true,
+        "esModuleInterop": true,
+        "module": "esnext",
+        "moduleResolution": "bundler",
+        "resolveJsonModule": true,
+        "isolatedModules": true,
+        "jsx": "react-jsx",
+        "incremental": true,
+        "paths": {
+            "lib/*": ["./lib/*"],
+            "ui/*": ["./ui/*"],
+            "styles/*": ["./styles/*"]
+        },
+        "plugins": [
+            {
+                "name": "next"
+            }
+        ]
+    },
+    "include": [
+        "next-env.d.ts",
+        "**/*.ts",
+        "**/*.tsx",
+        ".next/types/**/*.ts",
+        ".next/dev/types/**/*.ts"
     ],
-    "allowJs": true,
-    "skipLibCheck": true,
-    "strict": true,
-    "forceConsistentCasingInFileNames": true,
-    "noEmit": true,
-    "esModuleInterop": true,
-    "module": "esnext",
-    "moduleResolution": "bundler",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "jsx": "react-jsx",
-    "incremental": true,
-    "baseUrl": ".",
-    "plugins": [
-      {
-        "name": "next"
-      }
-    ]
-  },
-  "include": [
-    "next-env.d.ts",
-    "**/*.ts",
-    "**/*.tsx",
-    ".next/types/**/*.ts",
-    ".next/dev/types/**/*.ts"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+    "exclude": ["node_modules"]
 }

--- a/ui/NicoNicoEmbed.tsx
+++ b/ui/NicoNicoEmbed.tsx
@@ -12,6 +12,7 @@ const NicoNicoEmbed = ({videoId, title}: NicoNicoEmbedProps) => {
             height="176"
             src={`https://ext.nicovideo.jp/thumb/${videoId}`}
             style={{border: 'solid 1px #ccc'}}
+            title={title}
             allowFullScreen
         >
             <a href={`https://www.nicovideo.jp/watch/${videoId}`}>{title}</a>

--- a/ui/share-buttons.tsx
+++ b/ui/share-buttons.tsx
@@ -26,6 +26,7 @@ const ShareButtons = ({
                 target="_blank"
                 rel="noopener noreferrer"
                 className={styles.button}
+                aria-label="Xでシェア"
             >
                 <FaXTwitter color="#000000" />
             </a>
@@ -34,14 +35,16 @@ const ShareButtons = ({
                 target="_blank"
                 rel="noopener noreferrer"
                 className={styles.button}
+                aria-label="LINEでシェア"
             >
                 <FaLine color="#00c300" />
             </a>
             <a
-                href={`http://b.hatena.ne.jp/add?mode=confirm&url=${encodedUrl}`}
+                href={`https://b.hatena.ne.jp/add?mode=confirm&url=${encodedUrl}`}
                 target="_blank"
                 rel="noopener noreferrer"
                 className={styles.button}
+                aria-label="はてなブックマークに追加"
             >
                 <SiHatenabookmark color="#00a4de" />
             </a>
@@ -50,6 +53,7 @@ const ShareButtons = ({
                 target="_blank"
                 rel="noopener noreferrer"
                 className={styles.button}
+                aria-label="Facebookでシェア"
             >
                 <FaFacebook color="#1877f2" />
             </a>


### PR DESCRIPTION
サイト診断で挙げた点を一括対応しました（#14 二重h1・#15 gtagポーリングは後述の理由で本PRでは保留）。

## 🔴 ビルド性能
- **投稿/ディスコグラフィ一覧をプロダクションビルド中メモ化**（`lib/posts.ts`, `lib/discography.ts`）。従来は各静的生成ページが `getPost`/`getDiscographyItem` 経由で `getPostAll`/`getDiscographyAll` を呼び、毎回全件読み込み＋アイテムごとに `git log` を2回 exec → **O(N²)（63投稿で約16,000回のgit起動/ビルド）**。dev では無効化し編集を即反映。
  - 実測: **コールドビルド 約112s → 約46s**（fetchキャッシュ無しでも）。
- **tsconfig**: `target` es5→es2017（es5はTS6で非推奨＋不要なレガシー変換）、`baseUrl`→`paths` 移行。
- `staticPageGenerationTimeout` 3600→300。

## 🟡 SEO
- `metadataBase` と既定OG画像を追加（リンクプレビューの画像欠落を解消）。
- **記事ごとの meta description を本文から生成**（従来は全63記事が汎用説明文を継承＝重複）。
- **Article / BreadcrumbList の JSON-LD 構造化データ**を追加。

## 🟡 アクセシビリティ
- アイコンのみのシェアリンクに `aria-label`、検索inputに `aria-label`、NicoNico iframe に `title`。

## 🟢 整理
- `DisplayPosts` の不要な `'use client'` 除去（サーバーコンポーネント化）。
- はてブ共有リンクを `https` 化、SUZURIリンクに `target`/`rel`。
- ベースラインのセキュリティヘッダ追加（nosniff / X-Frame-Options / Referrer-Policy / HSTS / Permissions-Policy）。CSPはAdSense/GAを壊すリスクのため見送り。
- **`__tests__/lib/posts.test.ts` の潜在型バグを修正**（number型フィールドに文字列日付を代入していた）。es5非推奨エラーが型チェックを止めていたため隠れていたもの。

## 検証
- `tsc --noEmit`: クリーン（0エラー）
- `eslint .`: クリーン
- `next build`: 成功（71/71ページ、型チェック通過、46s）

## 本PRで見送った項目（理由）
- **#14 記事ページの二重 `<h1>`**（Headerのサイト名h1＋本文h1）: 修正にはHeaderのh1降格＋トップへのh1追加が必要で、レイアウト/見た目の回帰リスクに対し効果が小さいため別途。
- **#15 `GoogleAds` の gtagポーリング**: 広告コンバージョン計測の配線に関わり、検証なしの書き換えは収益計測を壊すリスクがあるため現状維持。
- （別途の発見）`npx jest` が `jest.config.ts` の `next/jest` 解決で失敗（ESM）。CIはテスト未実行のため本番に影響なし。希望あれば別PRで対応します。
