### PR TITLE
Allow r.r10s.jp image host for Rakuten product thumbnails

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -26,6 +26,15 @@ export default {
                 port: '',
                 pathname: '/**',
             },
+            {
+                // The Rakuten Product Search API (20250801) returns product
+                // images on this CDN host; without it next/image rejects them
+                // and the product thumbnails render blank.
+                protocol: 'https',
+                hostname: 'r.r10s.jp',
+                port: '',
+                pathname: '/**',
+            },
         ],
     },
     headers: async () => [


### PR DESCRIPTION
## 問題
商品画像（楽天の商品サムネイル）が全ページで表示されていませんでした。

## 原因
楽天の商品検索API（`Product/Search/20250801`）は `mediumImageUrl` を **`r.r10s.jp`** CDN で返しますが、`next.config.mjs` の `images.remotePatterns` には旧ホスト `thumbnail.image.rakuten.co.jp` しか登録されていませんでした。next/image は未登録ホストの画像を拒否するため、商品サムネイルが全て空表示になっていました（キャッシュ済み46件すべて `r.r10s.jp`）。

## 修正
`r.r10s.jp` を `remotePatterns` に追加。

## 検証
ローカルで `next build` → `next start` 後、画像最適化エンドポイントを確認:
- `r.r10s.jp` の画像 → **HTTP 200**（修正後）
- 制御: 未許可ホスト（example.com） → **HTTP 400**

最適化エンドポイントが `remotePatterns` を強制していることを制御テストで確認済みなので、200は確かな修正の証拠です。