### PR TITLE
Handle Rakuten products without an image

### DIFF
--- a/lib/rakuten.ts
+++ b/lib/rakuten.ts
@@ -39,7 +39,8 @@ type RakutenProductSearchResponse = {
             productName: string;
             brandName: string;
             productUrlPC: string;
-            mediumImageUrl: string;
+            // The API returns null when a product has no image.
+            mediumImageUrl: string | null;
             affiliateUrl?: string;
         };
     }[];
@@ -49,7 +50,7 @@ export type RakutenProduct = {
     productId: string;
     productName: string;
     affiliateUrl: string;
-    imageUrl: string;
+    imageUrl: string | null;
 };
 
 const fetchRakutenProduct = async (
@@ -156,7 +157,7 @@ const fetchRakutenProduct = async (
             productId: item.productId,
             productName: item.productName,
             affiliateUrl: item.affiliateUrl ?? item.productUrlPC,
-            imageUrl: item.mediumImageUrl,
+            imageUrl: item.mediumImageUrl ?? null,
         };
     } catch (error) {
         // A genuine "no product" result is cacheable; rethrow anything else so

--- a/ui/affiliates.tsx
+++ b/ui/affiliates.tsx
@@ -29,20 +29,22 @@ const Affiliates = async ({
         <div className={styles.card}>
             {rakutenProduct && (
                 <>
-                    <Link className={styles.imageContainer} href={cardUrl}>
-                        <Image
-                            src={rakutenProduct.imageUrl}
-                            alt={rakutenProduct.productName}
-                            width={200}
-                            height={200}
-                            style={{
-                                borderRadius: '10px',
-                                width: '85%',
-                                height: 'auto',
-                                boxShadow: 'var(--box-shadow-background)',
-                            }}
-                        />
-                    </Link>
+                    {rakutenProduct.imageUrl && (
+                        <Link className={styles.imageContainer} href={cardUrl}>
+                            <Image
+                                src={rakutenProduct.imageUrl}
+                                alt={rakutenProduct.productName}
+                                width={200}
+                                height={200}
+                                style={{
+                                    borderRadius: '10px',
+                                    width: '85%',
+                                    height: 'auto',
+                                    boxShadow: 'var(--box-shadow-background)',
+                                }}
+                            />
+                        </Link>
+                    )}
                     <Link className={styles.title} href={cardUrl}>
                         {truncateTitle(rakutenProduct.productName)}
                     </Link>


### PR DESCRIPTION
## 問題
`/blog/size-emulation-gaming-monitor` の「SONY INZONE M10S」など、一部の商品で画像が崩れて表示されていました（#1036 の r.r10s.jp 対応では直らなかった残り）。

## 原因
楽天の商品検索APIは、ヒットした商品でも **`mediumImageUrl: null`** を返すことがあります（"INZONE M10S" はモニター用の覗き見防止フィルター＝画像なし商品にマッチ）。`imageUrl` は `string` 型なのに null が代入され、`<Image src={null}>` となって画像が壊れていました。

## 修正
- `RakutenProduct.imageUrl` と APIレスポンス型の `mediumImageUrl` を `string | null` に（実態に合わせる）。
- 商品画像は `imageUrl` がある時だけ `<Image>` を描画。画像が無い場合もタイトルと各ストアボタンは表示。

## 検証
`next build` 後、該当ページのHTMLを確認:
- `src=""` / `src="null"` / `url=null` は皆無（壊れた画像出力なし）
- 商品タイトル・ボタンは表示される
- `tsc` / `eslint` クリーン

## 補足（コード外）
"INZONE M10S" のクエリが本体モニターではなくアクセサリ（覗き見防止フィルター）を拾っています。より適切な商品にしたい場合は、その投稿の `<Affiliates>` に `JAN`（本体のJANコード）を指定するか `query` を調整すると精度が上がります（本PRは画像崩れの恒久対策のみ）。