### PR TITLE
Make affiliate image and title non-clickable

### DIFF
--- a/ui/affiliates.tsx
+++ b/ui/affiliates.tsx
@@ -20,17 +20,12 @@ const Affiliates = async ({
         getYahooUrl(query, JAN),
     ]);
     const amazonUrl = getAmazonUrl(asin);
-    const cardUrl =
-        amazonUrl ??
-        (rakutenProduct ? rakutenProduct.affiliateUrl : null) ??
-        yahooUrl ??
-        '#';
     return (
         <div className={styles.card}>
             {rakutenProduct && (
                 <>
                     {rakutenProduct.imageUrl && (
-                        <Link className={styles.imageContainer} href={cardUrl}>
+                        <div className={styles.imageContainer}>
                             <Image
                                 src={rakutenProduct.imageUrl}
                                 alt={rakutenProduct.productName}
@@ -43,11 +38,11 @@ const Affiliates = async ({
                                     boxShadow: 'var(--box-shadow-background)',
                                 }}
                             />
-                        </Link>
+                        </div>
                     )}
-                    <Link className={styles.title} href={cardUrl}>
+                    <span className={styles.title}>
                         {truncateTitle(rakutenProduct.productName)}
-                    </Link>
+                    </span>
                 </>
             )}
             <div className={styles.buttonGroup}>


### PR DESCRIPTION
## 背景
アフィリエイトカードの商品画像とタイトルは楽天由来ですが、リンク先は `cardUrl`（asin優先＝**Amazon**）になっていました。

これには2つの問題がありました:
1. **規約面（グレー）**: 楽天APIの画像は楽天市場商品の宣伝目的で提供されるもので、それをAmazonへのリンクに使うのは「別目的の利用」と解釈されうる。
2. **正確性/UX**: 楽天のマッチ商品（画像・タイトル）とAmazonのasin商品は独立に検索されるため、両者がズレると別商品を指す（例: "INZONE M10S" が覗き見防止フィルターにマッチし、画像/タイトルとAmazon遷移先が食い違う）。

## 変更
商品画像とタイトルを**非リンクの表示要素**（`div`/`span`）に変更。遷移は各ストアボタン（Amazon / 楽天 / Yahoo!）のみに限定し、「どのストアへ飛ぶか」の曖昧さを排除。未使用になった `cardUrl` を削除。

## 検証
`next build` 後、該当ページHTMLで確認:
- 画像が Amazon アンカー内に含まれない（非リンク化を確認）
- ストアボタンのリンクは健在（`amazon.co.jp/dp/...` / `hb.afl.rakuten.co.jp` / `ck.jp.ap.valuecommerce`）
- `tsc` / `eslint` クリーン