### PR TITLE
Improve typography, image optimization, 404/error pages and PWA manifest

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -18,6 +18,7 @@ import styles from 'styles/app/blog/page.module.css';
 import Affiliates from 'ui/affiliates';
 import ApiCredit from 'ui/ApiCredit';
 import NicoNicoEmbed from 'ui/NicoNicoEmbed';
+import PostImage from 'ui/PostImage';
 import ShareButtons from 'ui/share-buttons';
 
 import Breadcrumbs from '../../Breadcrumbs';
@@ -105,7 +106,12 @@ const Page = async ({params}: {params: Promise<{slug: string}>}) => {
                     </p>
                     <MDXRemote
                         source={content}
-                        components={{Affiliates, YouTubeEmbed, NicoNicoEmbed}}
+                        components={{
+                            Affiliates,
+                            YouTubeEmbed,
+                            NicoNicoEmbed,
+                            img: PostImage,
+                        }}
                         options={{
                             mdxOptions: {
                                 remarkPlugins: [

--- a/app/discography/[slug]/page.tsx
+++ b/app/discography/[slug]/page.tsx
@@ -90,6 +90,7 @@ const Page = async ({params}: {params: Promise<{slug: string}>}) => {
                         alt={discographyItem.data.title}
                         width={350}
                         height={350}
+                        priority
                         style={{
                             objectFit: 'cover',
                             borderRadius: '16px',

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import Link from 'next/link';
+import styles from 'styles/app/notFound.module.css';
+
+const Error = ({
+    reset,
+}: {
+    error: Error & {digest?: string};
+    reset: () => void;
+}) => {
+    return (
+        <main className={styles.main}>
+            <h1>エラーが発生しました</h1>
+            <p>
+                ページの表示中に問題が発生しました。お手数ですが、再試行するかホームにお戻りください。
+            </p>
+            <div className={styles.links}>
+                <button type="button" onClick={reset} className={styles.button}>
+                    再試行
+                </button>
+                <Link href="/" className={styles.link}>
+                    ホームに戻る
+                </Link>
+            </div>
+        </main>
+    );
+};
+
+export default Error;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,7 +2,7 @@ import 'styles/global.css';
 
 import {GoogleAnalytics} from '@next/third-parties/google';
 import {defaultOgImage, siteUrl} from 'lib/siteMetadata';
-import type {Metadata} from 'next';
+import type {Metadata, Viewport} from 'next';
 import Script from 'next/script';
 
 import Footer from './footer';
@@ -41,6 +41,10 @@ export const metadata: Metadata = {
         creator: '@zalgo_video',
         images: [defaultOgImage],
     },
+};
+
+export const viewport: Viewport = {
+    themeColor: '#00aa90',
 };
 
 const RootLayout = ({children}: {children: React.ReactNode}) => {

--- a/app/loading.tsx
+++ b/app/loading.tsx
@@ -1,0 +1,11 @@
+import styles from 'styles/app/notFound.module.css';
+
+const Loading = () => {
+    return (
+        <main className={styles.main}>
+            <p>読み込み中...</p>
+        </main>
+    );
+};
+
+export default Loading;

--- a/app/manifest.ts
+++ b/app/manifest.ts
@@ -1,0 +1,26 @@
+import type {MetadataRoute} from 'next';
+
+const manifest = (): MetadataRoute.Manifest => ({
+    name: 'ざるご Official Website',
+    short_name: 'ざるご',
+    description:
+        '歌い手/ゲーム実況者/データサイエンティストであるざるごのオフィシャルウェブサイト',
+    start_url: '/',
+    display: 'standalone',
+    background_color: '#ebf2fa',
+    theme_color: '#00aa90',
+    icons: [
+        {
+            src: '/favicons/android-chrome-192x192.png',
+            sizes: '192x192',
+            type: 'image/png',
+        },
+        {
+            src: '/favicons/android-chrome-256x256.png',
+            sizes: '256x256',
+            type: 'image/png',
+        },
+    ],
+});
+
+export default manifest;

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,33 @@
+import type {Metadata} from 'next';
+import Link from 'next/link';
+import styles from 'styles/app/notFound.module.css';
+
+import Header from './header';
+
+export const metadata: Metadata = {
+    title: 'ページが見つかりません',
+};
+
+const NotFound = () => {
+    return (
+        <>
+            <Header />
+            <main className={styles.main}>
+                <h1>404 - ページが見つかりません</h1>
+                <p>
+                    お探しのページは存在しないか、移動・削除された可能性があります。
+                </p>
+                <div className={styles.links}>
+                    <Link href="/" className={styles.link}>
+                        ホームに戻る
+                    </Link>
+                    <Link href="/blog" className={styles.link}>
+                        ブログ一覧へ
+                    </Link>
+                </div>
+            </main>
+        </>
+    );
+};
+
+export default NotFound;

--- a/lib/remarkImagesToFullPaths.ts
+++ b/lib/remarkImagesToFullPaths.ts
@@ -1,3 +1,6 @@
+import path from 'path';
+
+import sharp from 'sharp';
 import {Node} from 'unist';
 import {is} from 'unist-util-is';
 import {visit} from 'unist-util-visit';
@@ -8,28 +11,53 @@ type ImageNode = {
     title?: string;
     alt?: string;
     data?: {
-        hProperties: {
-            class: string;
-            style: string;
-        };
+        hProperties: Record<string, unknown>;
     };
 } & Node;
 
 const remarkImagesToFullPaths = ({slug}: {slug: string}) => {
-    return (tree: Node) => {
+    return async (tree: Node) => {
+        const imageNodes: ImageNode[] = [];
         visit(tree, 'image', (node: unknown) => {
             if (is(node, 'image')) {
-                const imageNode = node as ImageNode;
-                const url = imageNode.url;
-                if (!url.startsWith('http')) {
-                    imageNode.url = `/posts/${slug}/${url}`;
-                }
-                imageNode.data ??= {hProperties: {class: '', style: ''}};
-                imageNode.data.hProperties.class = 'remark-image';
-                imageNode.data.hProperties.style =
-                    'max-width: 100%; height: auto;';
+                imageNodes.push(node as ImageNode);
             }
         });
+
+        await Promise.all(
+            imageNodes.map(async imageNode => {
+                const original = imageNode.url;
+                const isLocal = !original.startsWith('http');
+                if (isLocal) {
+                    imageNode.url = `/posts/${slug}/${original}`;
+                }
+                imageNode.data ??= {hProperties: {}};
+
+                // Read intrinsic dimensions of local images so the rendered
+                // <Image> can reserve space (avoids layout shift) and serve an
+                // optimized, responsive srcset. Remote images fall back to a
+                // plain <img> in the PostImage component.
+                if (isLocal) {
+                    try {
+                        const filePath = path.join(
+                            process.cwd(),
+                            'public',
+                            'posts',
+                            slug,
+                            original
+                        );
+                        const {width, height} =
+                            await sharp(filePath).metadata();
+                        if (width && height) {
+                            imageNode.data.hProperties.width = width;
+                            imageNode.data.hProperties.height = height;
+                        }
+                    } catch {
+                        // Dimensions unavailable; PostImage renders a plain img.
+                    }
+                }
+            })
+        );
     };
 };
 

--- a/styles/app/notFound.module.css
+++ b/styles/app/notFound.module.css
@@ -1,0 +1,37 @@
+.main {
+    max-width: 640px;
+    margin: 0 auto;
+    padding: 4rem 1rem;
+    text-align: center;
+}
+
+.links {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    justify-content: center;
+    margin-top: 2rem;
+}
+
+.link {
+    color: var(--c-primary);
+    text-decoration: none;
+    font-weight: bold;
+}
+
+.link:hover {
+    text-decoration: underline;
+}
+
+.button {
+    color: var(--c-primary);
+    background: none;
+    border: none;
+    cursor: pointer;
+    font: inherit;
+    font-weight: bold;
+}
+
+.button:hover {
+    text-decoration: underline;
+}

--- a/styles/global.css
+++ b/styles/global.css
@@ -17,6 +17,18 @@
 body {
     background-color: var(--c-background);
     color: var(--c-base);
+    font-family:
+        system-ui,
+        -apple-system,
+        'Segoe UI',
+        'Helvetica Neue',
+        'Hiragino Kaku Gothic ProN',
+        'Hiragino Sans',
+        'Noto Sans JP',
+        'Yu Gothic',
+        Meiryo,
+        sans-serif;
+    line-height: 1.7;
 }
 
 table {
@@ -66,27 +78,29 @@ nav.toc {
 
 /* Accordion Header (Summary) */
 nav.toc summary {
-  cursor: pointer;
-  font-weight: bold;
-  margin-bottom: 1rem;
-  list-style-position: inside;
-  padding: 0.75rem 1.25rem;
-  border-radius: 12px;
-  box-shadow: var(--box-shadow-background);
-  transition: all 0.2s ease-out;
+    cursor: pointer;
+    font-weight: bold;
+    margin-bottom: 1rem;
+    list-style-position: inside;
+    padding: 0.75rem 1.25rem;
+    border-radius: 12px;
+    box-shadow: var(--box-shadow-background);
+    transition: all 0.2s ease-out;
 }
 nav.toc summary:hover {
-  color: var(--c-primary);
-  transform: translateY(-2px);
-  box-shadow: 4px 4px 10px #c8ced5, -4px -4px 10px #ffffff;
+    color: var(--c-primary);
+    transform: translateY(-2px);
+    box-shadow:
+        4px 4px 10px #c8ced5,
+        -4px -4px 10px #ffffff;
 }
 nav.toc details[open] > summary {
-  margin-bottom: 1rem;
-  box-shadow: var(--box-shadow-foreground);
+    margin-bottom: 1rem;
+    box-shadow: var(--box-shadow-foreground);
 }
 nav.toc summary:active {
-  box-shadow: var(--box-shadow-foreground);
-  transform: translateY(1px);
+    box-shadow: var(--box-shadow-foreground);
+    transform: translateY(1px);
 }
 
 /* TOC list appears when details is open */
@@ -133,12 +147,12 @@ nav.toc a:hover {
 }
 
 .container {
-   display: flex;
-   flex-direction: row-reverse;
-   align-items: flex-start;
+    display: flex;
+    flex-direction: row-reverse;
+    align-items: flex-start;
 }
 
 .container > div {
-   flex: 1;
-   min-width: 0;
+    flex: 1;
+    min-width: 0;
 }

--- a/ui/PostImage.tsx
+++ b/ui/PostImage.tsx
@@ -1,0 +1,55 @@
+import Image from 'next/image';
+
+type PostImageProps = {
+    src?: string;
+    alt?: string;
+    title?: string;
+    width?: number | string;
+    height?: number | string;
+};
+
+const toNumber = (value: number | string | undefined): number | undefined => {
+    if (typeof value === 'number') {
+        return value;
+    }
+    if (typeof value === 'string' && value.trim() !== '') {
+        const parsed = Number.parseInt(value, 10);
+        return Number.isNaN(parsed) ? undefined : parsed;
+    }
+    return undefined;
+};
+
+// MDX `img` renderer. Local images come with intrinsic width/height injected by
+// remarkImagesToFullPaths, so they render through next/image (optimized,
+// responsive, no layout shift). Remote or unmeasured images fall back to a
+// plain responsive <img>.
+const PostImage = ({src, alt, title, width, height}: PostImageProps) => {
+    const w = toNumber(width);
+    const h = toNumber(height);
+
+    if (!src || !w || !h) {
+        return (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+                src={src}
+                alt={alt ?? ''}
+                title={title}
+                style={{maxWidth: '100%', height: 'auto'}}
+            />
+        );
+    }
+
+    return (
+        <Image
+            src={src}
+            alt={alt ?? ''}
+            title={title}
+            width={w}
+            height={h}
+            sizes="(max-width: 768px) 100vw, 768px"
+            style={{maxWidth: '100%', height: 'auto'}}
+        />
+    );
+};
+
+export default PostImage;


### PR DESCRIPTION
サイト診断（第2弾）で挙げた点を一括対応しました。

## 🟠 体感品質・パフォーマンス
- **#1 フォント**: `body` に和文サンセリフのシステムフォントstack＋`line-height` を指定。従来はブラウザ既定（多くでセリフ）でした。ダウンロード不要・ゼロコスト。
- **#2 投稿本文画像の最適化（CLS解消）**: `remarkImagesToFullPaths` が各ローカル画像の実寸を sharp で読み取り、新規 `PostImage` コンポーネントが **next/image** で描画（レスポンシブsrcset、width/heightで領域確保＝レイアウトシフト防止）。リモート/実寸不明の画像は素のレスポンシブ `<img>` にフォールバック。
- **#3 LCP画像に `priority`**: ディスコグラフィ詳細のヒーロー画像（単一なのでアンチパターンにならない）。

## 🟡 ページ体験・PWA
- **#4 カスタム404**: `app/not-found.tsx`（ホーム/ブログへの導線付き）。
- **#5 PWA manifest + theme-color**: `app/manifest.ts`（既存のアイコン資産を利用）と `viewport.themeColor`。
- **#6 error/loading 境界**: `app/error.tsx`（再試行ボタン付き）・`app/loading.tsx`。

## 検証（`next build`、生成HTML）
- 本文画像が `/_next/image?url=%2Fposts%2F...&w=640..3840&q=75` のレスポンシブsrcsetに変換、`width="1024" height="683"`（実寸）＋`sizes` 付与。最適化されていない生 `/posts/` img はゼロ。
- `manifest.webmanifest` ルート生成、`_not-found` 生成を確認。
- `tsc --noEmit` クリーン / `eslint .` クリーン / ビルド成功。

## 本バッチで見送った「細かい点」（理由）
- **ディスコグラフィの og:url**: Next の `openGraph` がセグメント間でシャローに上書きされる仕様で、部分指定だと他フィールドを失うため、別途まとめて整理する方が安全。
- **インラインstyleのCSS化**: 楽曲詳細の `text-align:center` は共有の `.title` クラス（ブログ記事と共用）に影響するため見送り。純粋に整形目的・回帰リスクありのため別PR推奨。
