### PR TITLE
Post Netlify preview URL as a PR comment

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -42,7 +42,15 @@ jobs:
                   reporter: github-pr-review
             - name: Build and deploy for preview
               if: ${{ github.event_name == 'pull_request' }}
-              run: npx netlify-cli deploy
+              id: deploy_preview
+              run: |
+                  DEPLOY_JSON=$(npx netlify-cli deploy --json)
+                  echo "$DEPLOY_JSON"
+                  URL=$(echo "$DEPLOY_JSON" | jq -r '.deploy_url // .url // empty')
+                  if [ -z "$URL" ]; then
+                      URL=$(echo "$DEPLOY_JSON" | grep -oE 'https://[a-z0-9.-]+\.netlify\.app' | head -n1)
+                  fi
+                  echo "preview_url=$URL" >> "$GITHUB_OUTPUT"
               env:
                   NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
                   NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
@@ -53,6 +61,25 @@ jobs:
                   VALUE_COMMERCE_PID: ${{ secrets.VALUE_COMMERCE_PID }}
                   VALUE_COMMERCE_SID: ${{ secrets.VALUE_COMMERCE_SID }}
                   YAHOO_API_APP_ID: ${{ secrets.YAHOO_API_APP_ID }}
+            - name: Comment preview URL on PR
+              if: ${{ github.event_name == 'pull_request' && steps.deploy_preview.outputs.preview_url != '' }}
+              uses: actions/github-script@v7
+              env:
+                  PREVIEW_URL: ${{ steps.deploy_preview.outputs.preview_url }}
+              with:
+                  script: |
+                      const url = process.env.PREVIEW_URL;
+                      const marker = '<!-- netlify-preview-url -->';
+                      const body = `${marker}\n🚀 **プレビューデプロイ**: ${url}\n\n<sub>このコメントはコミットごとに更新されます。</sub>`;
+                      const {owner, repo} = context.repo;
+                      const issue_number = context.issue.number;
+                      const {data: comments} = await github.rest.issues.listComments({owner, repo, issue_number});
+                      const existing = comments.find((c) => c.body && c.body.includes(marker));
+                      if (existing) {
+                          await github.rest.issues.updateComment({owner, repo, comment_id: existing.id, body});
+                      } else {
+                          await github.rest.issues.createComment({owner, repo, issue_number, body});
+                      }
             - name: Build and deploy for production
               if: ${{ github.event_name == 'push' }}
               run: npx netlify-cli deploy --prod


### PR DESCRIPTION
## 目的
PRのプレビューデプロイURLを**PRコメントに自動投稿**し、レビュー時にCIログを掘らなくても確認できるようにします。

## 変更（`.github/workflows/cicd.yaml`）
- プレビューデプロイを `netlify-cli deploy --json` にし、出力から `deploy_url` を取得（取得できない場合は `*.netlify.app` をログからフォールバック抽出）。**デプロイ挙動自体は不変**。
- `actions/github-script`（first-party）で、マーカー付きの**固定コメントを1つ upsert**（コミットごとに更新、コメント乱立を防止）。
- 既存の `pull-requests: write` 権限で動作。サードパーティ製アクションの追加なし。

## 検証
- `cicd.yaml` のYAMLをパース検証済み（全ステップ正常、コメントステップ＝`actions/github-script@v7`）。
- **本PR自体がワークフローを実行**するため、このPRに🚀プレビューURLコメントが投稿されれば動作確認完了です。

## 補足
プレビューURLは Netlify の各デプロイ固有URL（`https://<deploy-id>--<site>.netlify.app`）です。`concurrency.cancel-in-progress: true` のため、新しいpushで前のデプロイがキャンセルされた場合はコメントが更新されないことがあります（最新pushのデプロイ完了時に更新）。