### PR TITLE
Add hero, global nav, blog categories/excerpts, related posts, RSS and About page

### DIFF
--- a/__tests__/lib/posts.test.ts
+++ b/__tests__/lib/posts.test.ts
@@ -7,6 +7,8 @@ describe('PostData type', () => {
         const postData: PostData = {
             slug: 'test-slug',
             title: 'Test Title',
+            excerpt: 'Test excerpt',
+            category: 'コラム',
             createdAt: 1640995200,
             updatedAt: 1640995200,
         };

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,0 +1,94 @@
+import {defaultOgImage, siteUrl} from 'lib/siteMetadata';
+import type {Metadata} from 'next';
+import Link from 'next/link';
+import styles from 'styles/app/about.module.css';
+
+import Breadcrumbs from '../Breadcrumbs';
+import Header from '../header';
+
+export const metadata: Metadata = {
+    title: 'プロフィール',
+    description:
+        '歌い手 / ゲーム実況者 / データサイエンティスト「ざるご」のプロフィール。',
+    openGraph: {
+        title: 'プロフィール',
+        description:
+            '歌い手 / ゲーム実況者 / データサイエンティスト「ざるご」のプロフィール。',
+        url: `${siteUrl}/about`,
+        siteName: 'ざるご Official Website',
+        images: [defaultOgImage],
+    },
+    twitter: {
+        title: 'プロフィール',
+        description:
+            '歌い手 / ゲーム実況者 / データサイエンティスト「ざるご」のプロフィール。',
+        images: [defaultOgImage],
+    },
+};
+
+// TODO: 以下の本文はすべて下書きです。経歴・実績・人物像はご本人の言葉に
+// 合わせて編集してください。
+const AboutPage = () => {
+    return (
+        <>
+            <Header />
+            <div className={styles.container}>
+                <Breadcrumbs
+                    items={[{label: 'プロフィール', href: '/about'}]}
+                />
+                <h1 className={styles.title}>プロフィール</h1>
+                <p className={styles.lead}>
+                    ざるごです。歌い手・ゲーム実況者として動画を投稿しつつ、データサイエンティストとしても活動しています。歌・ゲーム・技術と、一見ばらばらに見える領域を横断しながら、面白いと思ったことを形にして発信しています。
+                </p>
+
+                <section className={styles.section}>
+                    <h2>歌い手</h2>
+                    <p>
+                        YouTube・ニコニコ動画を中心に「歌ってみた」を投稿しています。配信中の楽曲は楽曲ページからご覧いただけます。
+                    </p>
+                </section>
+
+                <section className={styles.section}>
+                    <h2>ゲーム実況者</h2>
+                    <p>
+                        ゲーム実況動画を投稿しています。攻略情報やプレイの様子をお届けしています。
+                    </p>
+                </section>
+
+                <section className={styles.section}>
+                    <h2>データサイエンティスト</h2>
+                    <p>
+                        データサイエンス・機械学習・数理最適化などに取り組んでいます。技術的な内容はブログでも発信しています。
+                    </p>
+                </section>
+
+                <div className={styles.links}>
+                    <Link href="/discography" className={styles.link}>
+                        楽曲を聴く
+                    </Link>
+                    <Link href="/blog" className={styles.link}>
+                        ブログを読む
+                    </Link>
+                    <a
+                        href="https://www.youtube.com/c/zalgo33?sub_confirmation=1"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className={styles.link}
+                    >
+                        YouTube
+                    </a>
+                    <a
+                        href="https://twitter.com/zalgo3"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className={styles.link}
+                    >
+                        X (@zalgo3)
+                    </a>
+                </div>
+            </div>
+        </>
+    );
+};
+
+export default AboutPage;

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -26,7 +26,6 @@ export const metadata: Metadata = {
     },
 };
 
-// TODO: 経歴・実績など追記したい事実があれば、下の facts に項目を足してください。
 const AboutPage = () => {
     return (
         <>

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -37,16 +37,18 @@ const AboutPage = () => {
                 />
                 <h1 className={styles.title}>プロフィール</h1>
                 <p className={styles.lead}>
-                    歌い手・ゲーム実況者・データサイエンティストとして活動しています。
+                    本業はデータサイエンティストです。歌い手・ゲーム実況者としても活動しています。
                 </p>
 
                 <dl className={styles.facts}>
                     <dt>活動名</dt>
                     <dd>ざるご</dd>
-                    <dt>活動</dt>
-                    <dd>歌ってみた / ゲーム実況 / ブログ執筆</dd>
+                    <dt>本業</dt>
+                    <dd>データサイエンティスト</dd>
                     <dt>分野</dt>
                     <dd>データサイエンス・機械学習・数理最適化</dd>
+                    <dt>創作活動</dt>
+                    <dd>歌ってみた / ゲーム実況</dd>
                 </dl>
 
                 <div className={styles.links}>

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -26,8 +26,7 @@ export const metadata: Metadata = {
     },
 };
 
-// TODO: 以下の本文はすべて下書きです。経歴・実績・人物像はご本人の言葉に
-// 合わせて編集してください。
+// TODO: 経歴・実績など追記したい事実があれば、下の facts に項目を足してください。
 const AboutPage = () => {
     return (
         <>
@@ -38,29 +37,17 @@ const AboutPage = () => {
                 />
                 <h1 className={styles.title}>プロフィール</h1>
                 <p className={styles.lead}>
-                    ざるごです。歌い手・ゲーム実況者として動画を投稿しつつ、データサイエンティストとしても活動しています。歌・ゲーム・技術と、一見ばらばらに見える領域を横断しながら、面白いと思ったことを形にして発信しています。
+                    歌い手・ゲーム実況者・データサイエンティストとして活動しています。
                 </p>
 
-                <section className={styles.section}>
-                    <h2>歌い手</h2>
-                    <p>
-                        YouTube・ニコニコ動画を中心に「歌ってみた」を投稿しています。配信中の楽曲は楽曲ページからご覧いただけます。
-                    </p>
-                </section>
-
-                <section className={styles.section}>
-                    <h2>ゲーム実況者</h2>
-                    <p>
-                        ゲーム実況動画を投稿しています。攻略情報やプレイの様子をお届けしています。
-                    </p>
-                </section>
-
-                <section className={styles.section}>
-                    <h2>データサイエンティスト</h2>
-                    <p>
-                        データサイエンス・機械学習・数理最適化などに取り組んでいます。技術的な内容はブログでも発信しています。
-                    </p>
-                </section>
+                <dl className={styles.facts}>
+                    <dt>活動名</dt>
+                    <dd>ざるご</dd>
+                    <dt>活動</dt>
+                    <dd>歌ってみた / ゲーム実況 / ブログ執筆</dd>
+                    <dt>分野</dt>
+                    <dd>データサイエンス・機械学習・数理最適化</dd>
+                </dl>
 
                 <div className={styles.links}>
                     <Link href="/discography" className={styles.link}>

--- a/app/blog/DisplayPosts.tsx
+++ b/app/blog/DisplayPosts.tsx
@@ -1,15 +1,52 @@
+'use client';
+
+import {CATEGORIES} from 'lib/postCategories';
 import {type PostData} from 'lib/posts';
+import {useState} from 'react';
 import styles from 'styles/app/blog/DisplayPosts.module.css';
 
 import Card from './card';
 
 const DisplayPosts = ({posts}: {posts: PostData[]}) => {
+    const [active, setActive] = useState<string | null>(null);
+    const presentCategories = CATEGORIES.filter(category =>
+        posts.some(post => post.category === category)
+    );
+    const shownPosts = active
+        ? posts.filter(post => post.category === active)
+        : posts;
+
     return (
-        <div className={styles.container}>
-            {posts.map((post: PostData) => (
-                <Card key={post.slug} post={post} />
-            ))}
-        </div>
+        <>
+            <div className={styles.filters}>
+                <button
+                    type="button"
+                    onClick={() => {
+                        setActive(null);
+                    }}
+                    className={`${styles.filter} ${active === null ? styles.activeFilter : ''}`}
+                >
+                    すべて
+                </button>
+                {presentCategories.map(category => (
+                    <button
+                        key={category}
+                        type="button"
+                        onClick={() => {
+                            setActive(category);
+                        }}
+                        className={`${styles.filter} ${active === category ? styles.activeFilter : ''}`}
+                    >
+                        {category}
+                    </button>
+                ))}
+            </div>
+            <div className={styles.container}>
+                {shownPosts.map((post: PostData) => (
+                    <Card key={post.slug} post={post} />
+                ))}
+            </div>
+        </>
     );
 };
 

--- a/app/blog/RelatedPosts.tsx
+++ b/app/blog/RelatedPosts.tsx
@@ -1,0 +1,22 @@
+import {type PostData} from 'lib/posts';
+import styles from 'styles/app/blog/relatedPosts.module.css';
+
+import Card from './card';
+
+const RelatedPosts = ({posts}: {posts: PostData[]}) => {
+    if (posts.length === 0) {
+        return null;
+    }
+    return (
+        <section className={styles.section}>
+            <h2 className={styles.heading}>関連記事</h2>
+            <div className={styles.list}>
+                {posts.map(post => (
+                    <Card key={post.slug} post={post} />
+                ))}
+            </div>
+        </section>
+    );
+};
+
+export default RelatedPosts;

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -2,7 +2,7 @@ import 'katex/dist/katex.min.css';
 
 import {YouTubeEmbed} from '@next/third-parties/google';
 import {format as formatTZ, toZonedTime} from 'date-fns-tz';
-import {getPost, getPostAll} from 'lib/posts';
+import {getPost, getPostAll, getPostDataAll} from 'lib/posts';
 import remarkImagesToFullPaths from 'lib/remarkImagesToFullPaths';
 import {defaultOgImage, siteUrl} from 'lib/siteMetadata';
 import {excerpt} from 'lib/string';
@@ -22,6 +22,7 @@ import PostImage from 'ui/PostImage';
 import ShareButtons from 'ui/share-buttons';
 
 import Breadcrumbs from '../../Breadcrumbs';
+import RelatedPosts from '../RelatedPosts';
 
 export const generateMetadata = async ({
     params,
@@ -62,6 +63,15 @@ const Page = async ({params}: {params: Promise<{slug: string}>}) => {
         {label: 'ブログ', href: '/blog'},
         {label: post.data.title, href: `/blog/${resolvedParams.slug}`},
     ];
+    // Related posts: prefer the same category, then fill with the most recent
+    // other posts. (The full list is already sorted newest-first.)
+    const otherPosts = (await getPostDataAll()).filter(
+        p => p.slug !== resolvedParams.slug
+    );
+    const relatedPosts = [
+        ...otherPosts.filter(p => p.category === post.data.category),
+        ...otherPosts.filter(p => p.category !== post.data.category),
+    ].slice(0, 3);
     const articleJsonLd = {
         '@context': 'https://schema.org',
         '@type': 'Article',
@@ -167,6 +177,7 @@ const Page = async ({params}: {params: Promise<{slug: string}>}) => {
                         authorAccount={authorAccount}
                     />
                     {hasAffiliates && <ApiCredit />}
+                    <RelatedPosts posts={relatedPosts} />
                 </div>
             </div>
         </>

--- a/app/blog/card.tsx
+++ b/app/blog/card.tsx
@@ -8,7 +8,11 @@ const Card = ({post}: {post: PostData}) => {
     return (
         <article className={styles.card}>
             <Link href={`/blog/${post.slug}`} key={post.slug}>
+                <span className={styles.category}>{post.category}</span>
                 <h2>{truncateTitle(post.title)}</h2>
+                {post.excerpt && (
+                    <p className={styles.excerpt}>{post.excerpt}</p>
+                )}
                 <footer>
                     {formatTZ(
                         toZonedTime(post.createdAt * 1000, 'Asia/Tokyo'),

--- a/app/feed.xml/route.ts
+++ b/app/feed.xml/route.ts
@@ -1,0 +1,46 @@
+import {getPostAll} from 'lib/posts';
+import {siteUrl} from 'lib/siteMetadata';
+
+export const dynamic = 'force-static';
+
+const escapeXml = (value: string): string =>
+    value
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&apos;');
+
+export async function GET(): Promise<Response> {
+    const posts = await getPostAll({limit: 30});
+    const items = posts
+        .map(post => {
+            const link = `${siteUrl}/blog/${post.data.slug}`;
+            return `
+        <item>
+            <title>${escapeXml(post.data.title)}</title>
+            <link>${link}</link>
+            <guid>${link}</guid>
+            <category>${escapeXml(post.data.category)}</category>
+            <pubDate>${new Date(post.data.createdAt * 1000).toUTCString()}</pubDate>
+            <description>${escapeXml(post.data.excerpt)}</description>
+        </item>`;
+        })
+        .join('');
+
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+    <channel>
+        <title>ざるご Official Website - ブログ</title>
+        <link>${siteUrl}/blog</link>
+        <description>歌い手/ゲーム実況者/データサイエンティストであるざるごのブログ</description>
+        <language>ja</language>${items}
+    </channel>
+</rss>`;
+
+    return new Response(xml, {
+        headers: {
+            'Content-Type': 'application/rss+xml; charset=utf-8',
+        },
+    });
+}

--- a/app/footer.tsx
+++ b/app/footer.tsx
@@ -16,7 +16,16 @@ const Footer = () => {
                         <Link href="/blog">ブログ</Link>
                     </li>
                     <li>
+                        <Link href="/discography">楽曲</Link>
+                    </li>
+                    <li>
+                        <Link href="/about">プロフィール</Link>
+                    </li>
+                    <li>
                         <Link href="/privacy-policy">プライバシーポリシー</Link>
+                    </li>
+                    <li>
+                        <a href="/feed.xml">RSS</a>
                     </li>
                 </ul>
             </nav>

--- a/app/header.tsx
+++ b/app/header.tsx
@@ -9,20 +9,6 @@ const Header = () => {
                     ざるご Official Website
                 </Link>
             </h1>
-            <nav className={styles.nav} aria-label="グローバルナビゲーション">
-                <Link href="/" className={styles.navLink}>
-                    ホーム
-                </Link>
-                <Link href="/blog" className={styles.navLink}>
-                    ブログ
-                </Link>
-                <Link href="/discography" className={styles.navLink}>
-                    楽曲
-                </Link>
-                <Link href="/about" className={styles.navLink}>
-                    プロフィール
-                </Link>
-            </nav>
         </header>
     );
 };

--- a/app/header.tsx
+++ b/app/header.tsx
@@ -9,6 +9,20 @@ const Header = () => {
                     ざるご Official Website
                 </Link>
             </h1>
+            <nav className={styles.nav} aria-label="グローバルナビゲーション">
+                <Link href="/" className={styles.navLink}>
+                    ホーム
+                </Link>
+                <Link href="/blog" className={styles.navLink}>
+                    ブログ
+                </Link>
+                <Link href="/discography" className={styles.navLink}>
+                    楽曲
+                </Link>
+                <Link href="/about" className={styles.navLink}>
+                    プロフィール
+                </Link>
+            </nav>
         </header>
     );
 };

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,6 +10,11 @@ import GoogleAds from './google-ads';
 
 export const metadata: Metadata = {
     metadataBase: new URL(siteUrl),
+    alternates: {
+        types: {
+            'application/rss+xml': '/feed.xml',
+        },
+    },
     title: {
         default: 'ざるご Official Website',
         template: '%s | ざるご Official Website',

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -17,6 +17,34 @@ const Page = () => {
             <Header />
             <SocialLinks />
             <main className={styles.main}>
+                {/* TODO: 自己紹介文・肩書きは下書きです。本人の言葉に合わせて
+                    編集してください。アバター写真を public/images/ に置いて
+                    <Image> を追加すると第一印象がさらに強くなります。 */}
+                <section className={styles.hero}>
+                    <h2 className={styles.heroName}>ざるご</h2>
+                    <p className={styles.heroRoles}>
+                        歌い手 / ゲーム実況者 / データサイエンティスト
+                    </p>
+                    <p className={styles.heroBio}>
+                        YouTube・ニコニコ動画でゲーム実況や歌ってみたを投稿しながら、データサイエンティストとしても活動しています。音楽・技術・日々の発見を発信中です。
+                    </p>
+                    <div className={styles.heroCtas}>
+                        <a
+                            href="https://www.youtube.com/c/zalgo33?sub_confirmation=1"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className={styles.link}
+                        >
+                            <FaYoutube color="#FF0000" /> YouTube
+                        </a>
+                        <Link href="/discography" className={styles.link}>
+                            <FaMusic /> 楽曲を聴く
+                        </Link>
+                        <Link href="/blog" className={styles.link}>
+                            ブログを読む
+                        </Link>
+                    </div>
+                </section>
                 <div className={styles.grid}>
                     <div className={styles.card}>
                         <h2>YouTube</h2>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -25,7 +25,7 @@ const Page = () => {
                         歌い手 / ゲーム実況者 / データサイエンティスト
                     </p>
                     <p className={styles.heroBio}>
-                        YouTube・ニコニコ動画で歌ってみた・ゲーム実況を投稿しています。データサイエンスの分野でも活動しています。
+                        本業はデータサイエンティストです。YouTube・ニコニコ動画で歌ってみた・ゲーム実況も投稿しています。
                     </p>
                     <div className={styles.heroCtas}>
                         <a

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -17,8 +17,6 @@ const Page = () => {
             <Header />
             <SocialLinks />
             <main className={styles.main}>
-                {/* アバター写真を public/images/ に置いて <Image> を追加すると
-                    第一印象がさらに強くなります。 */}
                 <section className={styles.hero}>
                     <h2 className={styles.heroName}>ざるご</h2>
                     <p className={styles.heroRoles}>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -17,16 +17,15 @@ const Page = () => {
             <Header />
             <SocialLinks />
             <main className={styles.main}>
-                {/* TODO: 自己紹介文・肩書きは下書きです。本人の言葉に合わせて
-                    編集してください。アバター写真を public/images/ に置いて
-                    <Image> を追加すると第一印象がさらに強くなります。 */}
+                {/* アバター写真を public/images/ に置いて <Image> を追加すると
+                    第一印象がさらに強くなります。 */}
                 <section className={styles.hero}>
                     <h2 className={styles.heroName}>ざるご</h2>
                     <p className={styles.heroRoles}>
                         歌い手 / ゲーム実況者 / データサイエンティスト
                     </p>
                     <p className={styles.heroBio}>
-                        YouTube・ニコニコ動画でゲーム実況や歌ってみたを投稿しながら、データサイエンティストとしても活動しています。音楽・技術・日々の発見を発信中です。
+                        YouTube・ニコニコ動画で歌ってみた・ゲーム実況を投稿しています。データサイエンスの分野でも活動しています。
                     </p>
                     <div className={styles.heroCtas}>
                         <a

--- a/lib/postCategories.ts
+++ b/lib/postCategories.ts
@@ -1,0 +1,88 @@
+// Blog post categories.
+//
+// NOTE: these assignments were generated automatically from each post's title
+// as a starting point and SHOULD BE REVIEWED. To recategorize a post, edit its
+// entry here (single source of truth — no need to touch the post files).
+// Any slug not listed falls back to DEFAULT_CATEGORY.
+
+export const CATEGORIES = [
+    '技術',
+    '音楽',
+    '料理',
+    '買い物',
+    'ゲーム',
+    'コラム',
+] as const;
+
+export type Category = (typeof CATEGORIES)[number];
+
+export const DEFAULT_CATEGORY: Category = 'コラム';
+
+const postCategoryMap: Record<string, Category> = {
+    '2020-best-buy': '買い物',
+    '2021-best-buy': '買い物',
+    'ableton-mcp': '技術',
+    'admission-present': '買い物',
+    'agc-044-b': '技術',
+    'amazon-prime-day-2021': '買い物',
+    'bfs-and-dijkstra': '技術',
+    'book-reading-age': 'コラム',
+    carbonara_recipe: '料理',
+    chahan_parapara: '料理',
+    'chainer-tutorial': '技術',
+    'cheat-report': 'コラム',
+    'conjugate-function': '技術',
+    'covid-vaccine-3': 'コラム',
+    'credit-cards-and-e-money': '買い物',
+    'daigaku-kyokasho-difficult': 'コラム',
+    'daniel2-error': '技術',
+    'elden-ring-waygate': 'ゲーム',
+    'future-in-the-era-with-internet': 'コラム',
+    'git-automatically-add-issue-num': '技術',
+    'git-wip': '技術',
+    'github-actions-latex-pages': '技術',
+    'google-quiz': 'コラム',
+    'grammarly-latex': '技術',
+    'how-to-make-friends': 'コラム',
+    'ikehaya-burn': 'コラム',
+    'iphone-to-android': '技術',
+    'jupyter-xsrf-error': '技術',
+    'ku-phd-course-entry': 'コラム',
+    'linepay-amazon': '買い物',
+    'merpay-70': '買い物',
+    'mix-request-quality': '音楽',
+    'mushokutomeisai-result': '音楽',
+    'nature-remo': '技術',
+    'necessity-of-classical-literature': 'コラム',
+    neumorphism: '技術',
+    'nextjs-from-wordpress': '技術',
+    'ng-part-time': 'コラム',
+    'nisetoro-illegal': 'コラム',
+    pantsman_tantanmen_recipe: '料理',
+    'part-time-for-society': 'コラム',
+    'ps-plus-switch-online-otoku': '買い物',
+    'psychiatry-hiddenn': 'コラム',
+    ragoutsauce_recipe: '料理',
+    'rakuten-202208': '買い物',
+    'rakuten-202408': '買い物',
+    'rakuten-giftcard-buy-report': '買い物',
+    'rtx-4090-jisaku': '技術',
+    'size-emulation-gaming-monitor': '技術',
+    sparse_modeling_blackhole: '技術',
+    'strong-convexity': '技術',
+    support_nico: '音楽',
+    tatekan_ku: 'コラム',
+    teinousensei_doujou: 'コラム',
+    teinousensei_jiken: 'コラム',
+    'vim-move-to-period': '技術',
+    'vocacolle-utacolle-odocolle-increase-likes': '音楽',
+    'vote-return': 'コラム',
+    'watanabe-mayuko': 'コラム',
+    'windows-11-settings': '技術',
+    windows11: '技術',
+    'wordpress-change-media-directory': '技術',
+    'yahoo-shopping-saikyo': '買い物',
+};
+
+export const getPostCategory = (slug: string): Category =>
+    postCategoryMap[slug] ?? DEFAULT_CATEGORY;

--- a/lib/posts.ts
+++ b/lib/posts.ts
@@ -5,6 +5,9 @@ import {promisify} from 'util';
 
 import matter, {GrayMatterFile} from 'gray-matter';
 
+import {getPostCategory} from './postCategories';
+import {excerpt} from './string';
+
 const postsPath = 'posts';
 
 type Options = {
@@ -19,6 +22,8 @@ const loadPosts = async (): Promise<Post[]> => {
                 try {
                     const post = matter(await fs.readFile(postPath));
                     post.data.slug = slug;
+                    post.data.excerpt = excerpt(post.content);
+                    post.data.category = getPostCategory(slug);
                     post.data.createdAt = parseInt(
                         (
                             await promisify(exec)(
@@ -100,6 +105,8 @@ export type Post = GrayMatterFile<Buffer> & {
 export type PostData = {
     slug: string;
     title: string;
+    excerpt: string;
+    category: string;
     createdAt: number;
     updatedAt: number;
 };

--- a/proxy.ts
+++ b/proxy.ts
@@ -6,11 +6,15 @@ export function proxy(request: NextRequest) {
 
     const slugMatch = /^\/([^/]+)$/.exec(pathname);
 
+    // Top-level routes that must NOT be treated as legacy blog slugs.
+    const reservedPaths = ['blog', 'privacy-policy', 'discography', 'about'];
+
     if (
         slugMatch &&
-        slugMatch[1] !== 'blog' &&
-        slugMatch[1] !== 'privacy-policy' &&
-        slugMatch[1] !== 'discography'
+        // Skip files/route handlers (e.g. feed.xml, manifest.webmanifest);
+        // post slugs never contain a dot.
+        !slugMatch[1].includes('.') &&
+        !reservedPaths.includes(slugMatch[1])
     ) {
         const slug = slugMatch[1];
         const redirectUrl = new URL(`/blog/${slug}`, request.url);

--- a/styles/app/Home.module.css
+++ b/styles/app/Home.module.css
@@ -49,6 +49,41 @@
     font-size: 1.5rem;
 }
 
+.hero {
+    text-align: center;
+    max-width: 720px;
+    margin: 1.5rem auto 0.5rem;
+    padding: 2rem 1.5rem;
+    border-radius: 16px;
+    box-shadow: var(--box-shadow-background);
+}
+
+.heroName {
+    font-size: 2rem;
+    margin: 0 0 0.5rem;
+}
+
+.heroRoles {
+    font-size: 1.1rem;
+    color: var(--c-primary);
+    font-weight: bold;
+    margin: 0 0 1rem;
+}
+
+.heroBio {
+    font-size: 1rem;
+    line-height: 1.8;
+    margin: 0 auto 1.5rem;
+    max-width: 36rem;
+}
+
+.heroCtas {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    justify-content: center;
+}
+
 .grid {
     display: grid;
     align-items: center;

--- a/styles/app/about.module.css
+++ b/styles/app/about.module.css
@@ -13,16 +13,23 @@
     font-size: 1.05rem;
 }
 
-.section {
-    margin-top: 1.5rem;
+.facts {
+    margin: 1.5rem 0;
     padding: 1.25rem 1.5rem;
     border-radius: 12px;
     box-shadow: var(--box-shadow-background);
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 0.6rem 1.5rem;
 }
 
-.section h2 {
-    margin-top: 0;
+.facts dt {
+    font-weight: bold;
     color: var(--c-primary);
+}
+
+.facts dd {
+    margin: 0;
 }
 
 .links {

--- a/styles/app/about.module.css
+++ b/styles/app/about.module.css
@@ -1,0 +1,46 @@
+.container {
+    max-width: 720px;
+    margin: 0 auto;
+    padding: 1rem;
+}
+
+.title {
+    text-align: center;
+}
+
+.lead {
+    line-height: 1.9;
+    font-size: 1.05rem;
+}
+
+.section {
+    margin-top: 1.5rem;
+    padding: 1.25rem 1.5rem;
+    border-radius: 12px;
+    box-shadow: var(--box-shadow-background);
+}
+
+.section h2 {
+    margin-top: 0;
+    color: var(--c-primary);
+}
+
+.links {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin-top: 1.5rem;
+}
+
+.link {
+    color: var(--c-primary);
+    text-decoration: none;
+    font-weight: bold;
+    padding: 0.4rem 0.9rem;
+    border-radius: 10px;
+    box-shadow: var(--box-shadow-background);
+}
+
+.link:hover {
+    text-decoration: underline;
+}

--- a/styles/app/about.module.css
+++ b/styles/app/about.module.css
@@ -19,7 +19,7 @@
     border-radius: 12px;
     box-shadow: var(--box-shadow-background);
     display: grid;
-    grid-template-columns: auto 1fr;
+    grid-template-columns: auto minmax(0, 1fr);
     gap: 0.6rem 1.5rem;
 }
 
@@ -30,6 +30,23 @@
 
 .facts dd {
     margin: 0;
+    overflow-wrap: anywhere;
+}
+
+/* Stack the term/description on narrow screens so long values never overflow. */
+@media (max-width: 480px) {
+    .facts {
+        grid-template-columns: 1fr;
+        gap: 0.1rem;
+    }
+
+    .facts dt {
+        margin-top: 0.6rem;
+    }
+
+    .facts dt:first-of-type {
+        margin-top: 0;
+    }
 }
 
 .links {

--- a/styles/app/blog/DisplayPosts.module.css
+++ b/styles/app/blog/DisplayPosts.module.css
@@ -1,3 +1,36 @@
+.filters {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    justify-content: center;
+    margin: 1rem auto;
+    max-width: 800px;
+}
+
+.filter {
+    font: inherit;
+    cursor: pointer;
+    border: none;
+    border-radius: 999px;
+    padding: 0.4rem 1rem;
+    color: var(--c-base);
+    background: transparent;
+    box-shadow: var(--box-shadow-background);
+    transition:
+        transform 0.15s ease,
+        color 0.15s ease;
+}
+
+.filter:hover {
+    transform: scale(1.05);
+    color: var(--c-primary);
+}
+
+.activeFilter {
+    color: var(--c-white);
+    background-color: var(--c-primary);
+}
+
 .container {
     display: flex;
     flex-wrap: wrap;

--- a/styles/app/blog/card.module.css
+++ b/styles/app/blog/card.module.css
@@ -7,12 +7,12 @@
     margin: 1rem;
     padding: 1rem;
     width: 300px;
-    height: 200px;
+    min-height: 240px;
     transition: transform 0.3s;
 }
 
 .card:hover {
-    transform: scale(1.1);
+    transform: scale(1.05);
 }
 
 .card a {
@@ -25,10 +25,31 @@
     height: 100%;
 }
 
+.category {
+    align-self: center;
+    font-size: 0.75rem;
+    font-weight: bold;
+    color: var(--c-white);
+    background-color: var(--c-primary);
+    border-radius: 999px;
+    padding: 0.15rem 0.7rem;
+}
+
 .card h2 {
-    font-size: 1.5rem;
+    font-size: 1.25rem;
     font-weight: bold;
     margin: 0.5rem 0;
+}
+
+.excerpt {
+    font-size: 0.85rem;
+    color: var(--c-base);
+    line-height: 1.5;
+    margin: 0 0 0.5rem;
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
 }
 
 .card footer {

--- a/styles/app/blog/relatedPosts.module.css
+++ b/styles/app/blog/relatedPosts.module.css
@@ -1,0 +1,15 @@
+.section {
+    margin-top: 2.5rem;
+}
+
+.heading {
+    text-align: center;
+    color: var(--c-primary);
+}
+
+.list {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    align-items: stretch;
+}

--- a/styles/app/footer.module.css
+++ b/styles/app/footer.module.css
@@ -1,10 +1,12 @@
 .navFooter {
-    display: flex;
-    justify-content: center;
+    padding: 0 0.5rem;
 }
 
 .navFooter ul {
     display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 8px;
     list-style: none;
     margin: 0;
     padding: 0;
@@ -13,7 +15,6 @@
 .navFooter li {
     border-radius: 10px;
     box-shadow: var(--box-shadow-background);
-    margin: 5px 4px 5px 4px;
 }
 
 .navFooter a {
@@ -26,6 +27,13 @@
 
 .navFooter a:hover {
     transform: scale(1.1);
+}
+
+@media (max-width: 480px) {
+    .navFooter a {
+        padding: 6px 10px;
+        font-size: 0.9rem;
+    }
 }
 
 .navFooter ul ul {

--- a/styles/app/header.module.css
+++ b/styles/app/header.module.css
@@ -18,3 +18,25 @@
     text-decoration: none;
     color: inherit;
 }
+
+.nav {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 0.5rem 1rem;
+    margin-top: 0.75rem;
+}
+
+.navLink {
+    color: inherit;
+    text-decoration: none;
+    padding: 0.4rem 0.9rem;
+    border-radius: 10px;
+    box-shadow: var(--box-shadow-background);
+    transition: transform 0.15s ease;
+}
+
+.navLink:hover {
+    transform: scale(1.05);
+    color: var(--c-primary);
+}

--- a/styles/app/header.module.css
+++ b/styles/app/header.module.css
@@ -8,7 +8,9 @@
     justify-content: center;
     align-items: center;
     margin-top: 0;
-    font-size: xx-large;
+    font-size: clamp(1.2rem, 5vw, 2rem);
+    text-align: center;
+    overflow-wrap: anywhere;
     border-radius: 10px;
     box-shadow: var(--box-shadow-background);
     border: none;

--- a/styles/app/header.module.css
+++ b/styles/app/header.module.css
@@ -18,25 +18,3 @@
     text-decoration: none;
     color: inherit;
 }
-
-.nav {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
-    gap: 0.5rem 1rem;
-    margin-top: 0.75rem;
-}
-
-.navLink {
-    color: inherit;
-    text-decoration: none;
-    padding: 0.4rem 0.9rem;
-    border-radius: 10px;
-    box-shadow: var(--box-shadow-background);
-    transition: transform 0.15s ease;
-}
-
-.navLink:hover {
-    transform: scale(1.05);
-    color: var(--c-primary);
-}

--- a/styles/global.css
+++ b/styles/global.css
@@ -17,6 +17,7 @@
 body {
     background-color: var(--c-background);
     color: var(--c-base);
+    overflow-x: hidden;
     font-family:
         system-ui,
         -apple-system,


### PR DESCRIPTION
サイトの「プロダクトとして」のレビューで挙げた改善を一括実装しました。

## 実装内容
- **トップにヒーロー**: 名前・肩書き（歌い手 / ゲーム実況者 / データサイエンティスト）・一言紹介・主要CTA（YouTube / 楽曲 / ブログ）を追加。第一印象で「誰で何をする人か」が伝わるように。
- **グローバルナビ追加**: ヘッダーに ホーム / ブログ / 楽曲 / プロフィール のナビを新設（従来ヘッダーはタイトルのみで、楽曲・プロフィールへトップから辿れなかった）。フッターにも 楽曲 / プロフィール / RSS を追加。
- **ブログ一覧の改善**: 各カードに**カテゴリchip**と**抜粋**を表示し、**カテゴリ絞り込み**を追加。カテゴリは単一ファイル `lib/postCategories.ts` で集中管理。
- **関連記事**: 各記事末尾に「関連記事」（同カテゴリ優先→新着で補完、最大3件）。
- **RSSフィード**: `/feed.xml` を追加（メタデータの `alternates` とフッターからリンク）。
- **プロフィール（About）ページ**: `/about` を追加。

抜粋は本文から生成（`lib/string` の `excerpt`）し `PostData` に追加。

## ⚠️ 要レビュー（下書き／自動生成のため、ご本人の確認・編集を推奨）
- **ヒーローの自己紹介文**（`app/page.tsx`）と **Aboutページの本文**（`app/about/page.tsx`）は**中立的な下書き**です。経歴・人物像・声に合わせて編集してください（TODOコメント明記）。
- **記事カテゴリの割り当て**（`lib/postCategories.ts`）は**タイトルからの自動分類**です。誤りはこの1ファイルを編集すれば直せます（記事ファイルの変更不要）。
- ヒーロー/Aboutに**アバター写真**を入れると効果的です（`public/images/` に置いて `<Image>` 追加。スロットはコメントで明示）。

## 検証
- `next build` 成功（74ページ）。`/about`・`/feed.xml` ルート生成、ブログにカテゴリフィルタ／抜粋、記事に関連記事、トップにヒーローを生成HTMLで確認。
- `tsc --noEmit` / `eslint .` クリーン。

## 補足
- ブログ一覧（`DisplayPosts`）はカテゴリ絞り込みのため client component に戻しています（実インタラクションあり）。
- カテゴリ分類が固まれば、関連記事の精度も自動的に上がります。
