### PR TITLE
Keep active blog category filter readable on hover

### DIFF
--- a/styles/app/blog/DisplayPosts.module.css
+++ b/styles/app/blog/DisplayPosts.module.css
@@ -26,7 +26,8 @@
     color: var(--c-primary);
 }
 
-.activeFilter {
+.activeFilter,
+.activeFilter:hover {
     color: var(--c-white);
     background-color: var(--c-primary);
 }


### PR DESCRIPTION
## 問題
ブログのカテゴリ絞り込みで、**選択中（アクティブ）のボタンの文字が読めない**。

## 原因
アクティブボタンは背景が `--c-primary`（テラル）ですが、`.filter:hover` が文字色を同じ `--c-primary` にしていたため、**テラル文字×テラル背景**で不可視に。スマホではタップ後に `:hover` 状態が残るため、押した直後から読めなくなっていました。

## 修正
`.activeFilter:hover` でも文字を白（`--c-white`）に維持。

## 検証
`next build` 成功。