### PR TITLE
Generate per-post OG images from the article title (Qiita-style)

### DIFF
--- a/app/blog/[slug]/opengraph-image.tsx
+++ b/app/blog/[slug]/opengraph-image.tsx
@@ -1,0 +1,118 @@
+import {getPostAll, getPost} from 'lib/posts';
+import {truncateTitle} from 'lib/string';
+import {ImageResponse} from 'next/og';
+
+export const size = {width: 1200, height: 630};
+export const contentType = 'image/png';
+export const alt = 'ざるご Official Website のブログ記事';
+
+export const generateStaticParams = async () => {
+    const posts = await getPostAll();
+    return posts.map(post => ({slug: post.data.slug}));
+};
+
+// Fetch only the glyphs used in this image as a Noto Sans JP subset. This old
+// macOS Safari User-Agent makes Google Fonts return a TTF; satori cannot parse
+// the woff2 that modern User-Agents receive. Retried a few times so a transient
+// build-time network hiccup doesn't fail the whole build.
+const FONT_USER_AGENT =
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_6_0) AppleWebKit/533.4 (KHTML, like Gecko) Version/4.1 Safari/533.4';
+
+const loadFont = async (text: string): Promise<ArrayBuffer> => {
+    let lastError: unknown;
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+        try {
+            const api = `https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@700&text=${encodeURIComponent(text)}`;
+            const css = await fetch(api, {
+                headers: {'User-Agent': FONT_USER_AGENT},
+            }).then(response => response.text());
+            const fontUrl =
+                /src:\s*url\((https:[^)]+)\)\s*format\('truetype'\)/.exec(
+                    css
+                )?.[1];
+            if (!fontUrl) {
+                throw new Error('Noto Sans JP truetype subset not found');
+            }
+            return await fetch(fontUrl).then(response =>
+                response.arrayBuffer()
+            );
+        } catch (error) {
+            lastError = error;
+        }
+    }
+    throw lastError instanceof Error
+        ? lastError
+        : new Error('Failed to load font');
+};
+
+const Image = async ({
+    params,
+}: {
+    params: Promise<{slug: string}>;
+}): Promise<ImageResponse> => {
+    const {slug} = await params;
+    const {data} = await getPost(slug);
+    const title = truncateTitle(data.title);
+    const siteName = 'ざるご Official Website';
+
+    const fontData = await loadFont(`${title}ブログ${siteName}`);
+
+    return new ImageResponse(
+        <div
+            style={{
+                width: '100%',
+                height: '100%',
+                display: 'flex',
+                flexDirection: 'column',
+                justifyContent: 'space-between',
+                padding: '80px',
+                backgroundColor: '#ebf2fa',
+                fontFamily: 'NotoSansJP',
+            }}
+        >
+            <div
+                style={{
+                    display: 'flex',
+                    fontSize: 40,
+                    fontWeight: 700,
+                    color: '#00aa90',
+                }}
+            >
+                ブログ
+            </div>
+            <div
+                style={{
+                    display: 'flex',
+                    fontSize: 64,
+                    fontWeight: 700,
+                    color: '#3b3d3f',
+                    lineHeight: 1.3,
+                }}
+            >
+                {title}
+            </div>
+            <div
+                style={{
+                    display: 'flex',
+                    fontSize: 36,
+                    color: '#3b3d3f',
+                }}
+            >
+                {siteName}
+            </div>
+        </div>,
+        {
+            ...size,
+            fonts: [
+                {
+                    name: 'NotoSansJP',
+                    data: fontData,
+                    weight: 700,
+                    style: 'normal',
+                },
+            ],
+        }
+    );
+};
+
+export default Image;

--- a/app/blog/[slug]/opengraph-image.tsx
+++ b/app/blog/[slug]/opengraph-image.tsx
@@ -63,9 +63,7 @@ const Image = async ({
                 width: '100%',
                 height: '100%',
                 display: 'flex',
-                flexDirection: 'column',
-                justifyContent: 'space-between',
-                padding: '80px',
+                padding: '56px',
                 backgroundColor: '#ebf2fa',
                 fontFamily: 'NotoSansJP',
             }}
@@ -73,32 +71,54 @@ const Image = async ({
             <div
                 style={{
                     display: 'flex',
-                    fontSize: 40,
-                    fontWeight: 700,
-                    color: '#00aa90',
+                    flexDirection: 'column',
+                    justifyContent: 'space-between',
+                    width: '100%',
+                    height: '100%',
+                    padding: '72px',
+                    borderRadius: '40px',
+                    backgroundColor: '#ebf2fa',
+                    boxShadow:
+                        '18px 18px 44px #c8ced5, -18px -18px 44px #ffffff',
                 }}
             >
-                ブログ
-            </div>
-            <div
-                style={{
-                    display: 'flex',
-                    fontSize: 64,
-                    fontWeight: 700,
-                    color: '#3b3d3f',
-                    lineHeight: 1.3,
-                }}
-            >
-                {title}
-            </div>
-            <div
-                style={{
-                    display: 'flex',
-                    fontSize: 36,
-                    color: '#3b3d3f',
-                }}
-            >
-                {siteName}
+                <div style={{display: 'flex'}}>
+                    <div
+                        style={{
+                            display: 'flex',
+                            fontSize: 34,
+                            fontWeight: 700,
+                            color: '#00aa90',
+                            padding: '10px 30px',
+                            borderRadius: '9999px',
+                            backgroundColor: '#ebf2fa',
+                            boxShadow:
+                                '6px 6px 14px #c8ced5, -6px -6px 14px #ffffff',
+                        }}
+                    >
+                        ブログ
+                    </div>
+                </div>
+                <div
+                    style={{
+                        display: 'flex',
+                        fontSize: 62,
+                        fontWeight: 700,
+                        color: '#3b3d3f',
+                        lineHeight: 1.3,
+                    }}
+                >
+                    {title}
+                </div>
+                <div
+                    style={{
+                        display: 'flex',
+                        fontSize: 34,
+                        color: '#3b3d3f',
+                    }}
+                >
+                    {siteName}
+                </div>
             </div>
         </div>,
         {

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -4,7 +4,7 @@ import {YouTubeEmbed} from '@next/third-parties/google';
 import {format as formatTZ, toZonedTime} from 'date-fns-tz';
 import {getPost, getPostAll, getPostDataAll} from 'lib/posts';
 import remarkImagesToFullPaths from 'lib/remarkImagesToFullPaths';
-import {defaultOgImage, siteUrl} from 'lib/siteMetadata';
+import {siteUrl} from 'lib/siteMetadata';
 import {excerpt} from 'lib/string';
 import type {Metadata} from 'next';
 import {MDXRemote} from 'next-mdx-remote/rsc';
@@ -41,12 +41,10 @@ export const generateMetadata = async ({
             description,
             url,
             type: 'article',
-            images: [defaultOgImage],
         },
         twitter: {
             title: data.title,
             description,
-            images: [defaultOgImage],
         },
     };
 };


### PR DESCRIPTION
## 概要
記事ごとに、タイトルから **OGP画像（1200×630）を自動生成**します（Qiitaのようなイメージ）。`app/blog/[slug]/opengraph-image.tsx` を追加し、`next/og` の `ImageResponse` でカードを描画します。

レイアウト: 左上「ブログ」（テラル）／中央に記事タイトル（太字・自動折返し）／下に「ざるご Official Website」／淡い背景。

## 日本語フォント
`next/og`(satori) の標準フォントは日本語非対応のため、**そのタイトルに含まれる字だけのサブセット**を Google Fonts から取得します。
- 取得形式は **TTF**（satoriはwoff2不可）。modern UAだとwoff2が返るため、**古いmacOS Safari UA** を指定してTTFを得る。
- 取得失敗に備え**リトライ**。リポジトリにフォントを同梱しない軽量方式。

記事メタの静的OG画像指定は重複防止のため削除し、`og:image`/`twitter:image` が生成画像を指すようにしました。

## 検証
- `next build` 成功（OG画像ルート137件生成、warmで約12s）。
- 生成画像を実際に確認し、**日本語タイトルが豆腐にならず正しく描画**されることを確認（例: 「2020年買ってよかったものランキング」）。
- 記事HTMLの `og:image`/`twitter:image` が生成画像を指し、重複なし（1個）を確認。
- `tsc` / `eslint` クリーン。